### PR TITLE
feat: advance check UX -- show context and signal pending input (#21)

### DIFF
--- a/.project_team/advance_check_ux/SPEC.md
+++ b/.project_team/advance_check_ux/SPEC.md
@@ -1,0 +1,687 @@
+# SPEC: Advance Check UX -- Show Context and Signal Pending Input
+
+**Issue:** #21
+**Status:** Draft (Rev 4)
+**Date:** 2026-04-12
+
+---
+
+## 1. Summary
+
+When a `manual-confirm` advance check or guardrail `request_override` fires,
+the user currently sees a generic prompt with no domain context. If the
+requesting agent is not the active tab, there is no visual signal that input is
+needed.
+
+This spec adds three capabilities to BOTH prompt types:
+
+1. **Domain context in prompts** -- advance checks show phase name/progress;
+   guardrail overrides show rule ID and severity. Both show the action detail
+   as a subtitle.
+2. **NEEDS_INPUT status on the requesting agent** -- the sidebar orange dot
+   appears while any approval prompt is waiting.
+3. **Toast notification for non-active agents** -- a notification tells the
+   user which agent needs approval, without auto-switching tabs. Toasts are
+   debounced per agent+key to prevent spam from retry loops.
+
+---
+
+## 2. Canonical Terminology
+
+Use these terms exactly in code, comments, and commit messages.
+
+| Term | Meaning |
+|------|---------|
+| **advance check** | Gate condition evaluated during phase transition (AND semantics, short-circuit). |
+| **manual-confirm** | Built-in check type requiring user interaction via `AsyncConfirmCallback`. |
+| **confirm prompt** | The `SelectionPrompt` shown for a manual-confirm advance check. |
+| **override prompt** | The `SelectionPrompt` shown for a guardrail deny-level rule override. |
+| **agent prompt** | The shared UX pattern: mount `SelectionPrompt` + set `NEEDS_INPUT` + toast + restore status. Both confirm prompt and override prompt are agent prompts. |
+| **phase context** | The workflow phase metadata (name, index, total phases) shown in the confirm prompt header. NOT the phase prompt text (identity.md + phase.md). |
+| **rule context** | The guardrail rule metadata (rule ID, blocked tool, severity) shown in the override prompt header. |
+| **NEEDS_INPUT status** | `AgentStatus.NEEDS_INPUT` -- triggers the orange sidebar indicator. |
+| **needs-attention** | CSS class on `HamburgerButton` for collapsed-sidebar highlight. Already exists. |
+| **agent focus** | NOT auto-switching tabs. Defined as: set `NEEDS_INPUT` status + show toast notification. The user decides when to switch. |
+
+---
+
+## 3. Architecture
+
+Shared `_show_agent_prompt()` helper with two thin callers. Both advance check
+confirm prompts and guardrail override prompts use the same UX pattern
+(NEEDS_INPUT, toast with debounce, status restore) -- only the parameters
+differ. See Appendix A for decision rationale.
+
+---
+
+## 4. File-by-File Changes
+
+All paths relative to `submodules/claudechic/claudechic/`.
+
+### 4.1 `checks/protocol.py` -- Widen the callback seam
+
+**What:** Add an optional context dict parameter to `AsyncConfirmCallback`.
+
+**Before:**
+```python
+AsyncConfirmCallback = Callable[[str], Awaitable[bool]]
+```
+
+**After:**
+```python
+AsyncConfirmCallback = Callable[[str, dict[str, Any] | None], Awaitable[bool]]
+"""The seam between ManualConfirm and the TUI.
+
+ManualConfirm calls: await callback(question, context) -> bool
+  - question: the prompt string from YAML
+  - context: optional dict with phase metadata (may be None)
+    Keys when present: "phase_id", "phase_index", "phase_total", "check_id"
+
+The engine creates the callback, closing over app methods.
+ManualConfirm never imports anything from claudechic.widgets or app.
+"""
+```
+
+**Import addition:** Add `Any` to the existing `typing` import.
+
+**Why:** The callback is the seam between engine and TUI. Widening it with an
+optional dict passes phase metadata without coupling engine to TUI internals.
+The dict is intentionally untyped (not a dataclass) to keep `protocol.py` as a
+leaf module with no upward imports.
+
+---
+
+### 4.2 `checks/builtins.py` -- Pass context through ManualConfirm
+
+**What:** Update `ManualConfirm` to accept and forward an optional context dict.
+
+**Before:**
+```python
+class ManualConfirm:
+    def __init__(self, question: str, confirm_fn: AsyncConfirmCallback) -> None:
+        self.question = question
+        self.confirm_fn = confirm_fn
+
+    async def check(self) -> CheckResult:
+        try:
+            confirmed = await self.confirm_fn(self.question)
+```
+
+**After:**
+```python
+class ManualConfirm:
+    def __init__(
+        self,
+        question: str,
+        confirm_fn: AsyncConfirmCallback,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        self.question = question
+        self.confirm_fn = confirm_fn
+        self.context = context
+
+    async def check(self) -> CheckResult:
+        try:
+            confirmed = await self.confirm_fn(self.question, self.context)
+```
+
+**Registration update:** Update the `manual-confirm` registration lambda to
+forward the `context` key from params:
+
+```python
+register_check_type(
+    "manual-confirm",
+    lambda p: ManualConfirm(
+        question=p.get("question") or p.get("prompt", "Confirm?"),
+        confirm_fn=p["confirm_fn"],
+        context=p.get("context"),
+    ),
+)
+```
+
+**Import addition:** Add `Any` to the existing `typing` import if not present.
+
+---
+
+### 4.3 `workflows/engine.py` -- Inject phase context into check params
+
+**What:** In `_run_single_check()`, when building a `manual-confirm` check,
+add phase context to the params dict. Read phase info at invocation time (not
+closure time) to avoid stale data.
+
+**Add `asyncio.Lock`** to prevent concurrent `attempt_phase_advance` calls
+from showing double prompts.
+
+**Changes to `__init__`:**
+```python
+def __init__(self, manifest, persist_fn, confirm_callback):
+    # ... existing init ...
+    self._advance_lock = asyncio.Lock()  # NEW: prevent concurrent advance
+```
+
+**Changes to `attempt_phase_advance`:**
+```python
+async def attempt_phase_advance(self, ...):
+    async with self._advance_lock:
+        # ... existing body (indented one level) ...
+```
+
+**Changes to `_run_single_check`:**
+```python
+async def _run_single_check(self, check_decl: CheckDecl) -> CheckResult:
+    try:
+        params = dict(check_decl.params)
+        if check_decl.type == "manual-confirm":
+            params["confirm_fn"] = self._confirm_callback
+            # Inject phase context at invocation time (not closure time)
+            current = self._current_phase
+            phase_order = self._phase_order
+            phase_index = (
+                phase_order.index(current) + 1 if current in phase_order else 0
+            )
+            params["context"] = {
+                "phase_id": current,
+                "phase_index": phase_index,
+                "phase_total": len(phase_order),
+                "check_id": check_decl.id,
+            }
+        # ... rest unchanged ...
+```
+
+**Import addition:** Add `import asyncio` at the top.
+
+---
+
+### 4.4 `mcp.py` -- Pass calling agent to both prompt flows
+
+**What:** Convert both `advance_phase` and `request_override` from bare
+functions to factories so they know which agent triggered the prompt.
+
+#### 4.4.a `advance_phase` -> `_make_advance_phase(caller_name)`
+
+```python
+def _make_advance_phase(caller_name: str | None = None):
+    """Create advance_phase tool with caller name bound."""
+
+    @tool(
+        "advance_phase",
+        "Advance the active workflow to its next phase. ...",
+        {},
+    )
+    async def advance_phase(args: dict[str, Any]) -> dict[str, Any]:
+        if _app is None or _app._workflow_engine is None:
+            return _error_response("No active workflow")
+        _track_mcp_tool("advance_phase")
+
+        engine = _app._workflow_engine
+
+        # Resolve calling agent for NEEDS_INPUT status
+        caller_agent = None
+        if caller_name and _app.agent_mgr:
+            caller_agent = _app.agent_mgr.find_by_name(caller_name)
+
+        # Temporarily set agent-aware confirm callback
+        original_cb = engine._confirm_callback
+        engine._confirm_callback = _app._make_confirm_callback(agent=caller_agent)
+        try:
+            current = engine.get_current_phase()
+            # ... rest of existing logic unchanged ...
+        finally:
+            engine._confirm_callback = original_cb
+
+    return advance_phase
+```
+
+#### 4.4.b `request_override` -> `_make_request_override(caller_name)`
+
+```python
+def _make_request_override(caller_name: str | None = None):
+    """Create request_override tool with caller name bound."""
+
+    @tool(
+        "request_override",
+        "Request user approval to override a deny-level rule. ...",
+        { ... },  # existing schema unchanged
+    )
+    async def request_override(args: dict[str, Any]) -> dict[str, Any]:
+        if _app is None or _app._token_store is None:
+            return _error_response("App not initialized")
+        _track_mcp_tool("request_override")
+
+        rule_id = args["rule_id"]
+        tool_name = args["tool_name"]
+        tool_input = args.get("tool_input", {})
+
+        description = (
+            f"Agent wants to run blocked action:\n"
+            f"  Tool: {tool_name}\n"
+            f"  Input: {_format_tool_input(tool_input)}\n"
+            f"  Blocked by: {rule_id}\n"
+            f"Approve this specific action?"
+        )
+
+        # Resolve calling agent for NEEDS_INPUT status
+        caller_agent = None
+        if caller_name and _app.agent_mgr:
+            caller_agent = _app.agent_mgr.find_by_name(caller_name)
+
+        approved = await _app._show_override_prompt(
+            rule_id, description, agent=caller_agent,
+        )
+
+        if approved:
+            _app._token_store.store(
+                rule_id, tool_name, tool_input, enforcement="deny",
+            )
+            return _text_response(
+                f"Override approved for rule {rule_id}. "
+                f"Retry the exact same command."
+            )
+        else:
+            return _text_response("Override denied.")
+
+    return request_override
+```
+
+#### 4.4.c `create_chic_server` updates
+
+```python
+# Replace:
+advance_phase,
+# With:
+_make_advance_phase(caller_name),
+
+# Replace:
+request_override,
+# With:
+_make_request_override(caller_name),
+```
+
+---
+
+### 4.5 `app.py` -- Shared helper + two thin callers
+
+This is the core of the architectural change. We extract the shared UX
+pattern into `_show_agent_prompt()`, then both advance checks and guardrail
+overrides call it with different parameters.
+
+#### 4.5.a `_show_agent_prompt` -- New shared helper (the compositional law)
+
+Add this new method near `_show_override_prompt` (around line 690). This is the
+**single implementation** of the "agent needs user approval" UX pattern:
+
+```python
+async def _show_agent_prompt(
+    self,
+    title: str,
+    options: list[tuple[str, str]],
+    subtitle: str | None = None,
+    agent: Agent | None = None,
+    toast_message: str | None = None,
+    toast_key: str | None = None,
+    post_deny_message: str | None = None,
+) -> str | None:
+    """Show an approval prompt with agent awareness.
+
+    This is the shared UX law for all "agent needs user approval"
+    interactions. Handles: mount SelectionPrompt, set NEEDS_INPUT on
+    the requesting agent, toast if non-active, restore status after.
+
+    Callers provide domain-specific parameters (title, options, etc.)
+    without duplicating the agent-awareness logic.
+
+    Args:
+        title: Prompt title (ASCII only, no emoji).
+        options: List of (value, label) tuples for SelectionPrompt.
+        subtitle: Optional detail text below the title.
+        agent: The agent requesting approval. If None, uses active agent.
+        toast_message: Notification shown when agent is not active tab.
+            If None, no toast is shown.
+        toast_key: Deduplication key for toast_message. If a toast with
+            the same key was shown within TOAST_COOLDOWN_SECONDS, the
+            toast is suppressed (the prompt still shows). Typically
+            "{agent_id}:{domain_id}" (e.g., "agent-1:no_pip_install").
+            If None, toast is always shown (no debounce).
+        post_deny_message: Toast shown after user selects a deny-equivalent
+            option (any option whose value is not "allow"). If None, no
+            post-deny toast.
+
+    Returns:
+        The selected option value (str), or None if cancelled.
+    """
+    from claudechic.widgets.prompts import SelectionPrompt
+
+    target_agent = agent or self._agent
+    previous_status = None
+
+    # Set NEEDS_INPUT on the requesting agent
+    if target_agent:
+        previous_status = target_agent.status
+        target_agent._set_status(AgentStatus.NEEDS_INPUT)
+
+        # Toast if this agent is not the active tab (with debounce)
+        if toast_message and target_agent.id != self.active_agent_id:
+            if self._should_show_toast(toast_key):
+                self.notify(toast_message, severity="information")
+
+    try:
+        prompt = SelectionPrompt(title, options, subtitle=subtitle)
+        async with self._show_prompt(prompt, agent=target_agent):
+            result = await prompt.wait()
+
+        # Post-deny feedback
+        if result != "allow" and post_deny_message:
+            self.notify(post_deny_message, severity="warning")
+
+        return result
+    except Exception as e:
+        log.warning("Agent prompt error: %s", e)
+        return None  # Treat as cancel
+    finally:
+        if target_agent and previous_status is not None:
+            restore_status = (
+                previous_status
+                if previous_status != AgentStatus.NEEDS_INPUT
+                else AgentStatus.BUSY
+            )
+            target_agent._set_status(restore_status)
+```
+
+#### 4.5.b Toast debounce helper
+
+Add instance state in `ChatApp.__init__` (or `on_mount`):
+
+```python
+self._toast_timestamps: dict[str, float] = {}
+```
+
+Add constant at class level:
+
+```python
+TOAST_COOLDOWN_SECONDS: float = 10.0
+```
+
+Add private helper:
+
+```python
+def _should_show_toast(self, toast_key: str | None) -> bool:
+    """Check whether a toast should be shown, enforcing per-key cooldown.
+
+    Returns True if:
+    - toast_key is None (no debounce requested), OR
+    - No toast with this key was shown within TOAST_COOLDOWN_SECONDS.
+
+    When returning True, records the current timestamp for the key.
+    """
+    if toast_key is None:
+        return True
+    now = time.monotonic()
+    last_shown = self._toast_timestamps.get(toast_key, 0.0)
+    if now - last_shown < self.TOAST_COOLDOWN_SECONDS:
+        return False
+    self._toast_timestamps[toast_key] = now
+    return True
+```
+
+**Import addition:** Add `import time` at the top of `app.py` (stdlib, no
+boundary violation).
+
+**Why toast_key, not automatic dedup on toast_message?** Different prompts
+can have the same message text but different semantic contexts. The key gives
+callers explicit control: override prompts key on `"{agent_id}:{rule_id}"`,
+advance checks key on `"{agent_id}:advance"`. The helper is prompt-type-agnostic
+-- no `if` branches on what kind of prompt is being shown.
+
+---
+
+#### 4.5.c `_show_advance_check_prompt` -- Thin caller for advance checks
+
+```python
+async def _show_advance_check_prompt(
+    self,
+    question: str,
+    context: dict[str, Any] | None = None,
+    agent: Agent | None = None,
+) -> bool:
+    """Show confirm prompt for manual-confirm advance checks.
+
+    Thin caller over _show_agent_prompt with phase context formatting.
+    """
+    # Build phase context header
+    header = "Confirm phase advance"
+    if context:
+        phase_id = context.get("phase_id", "")
+        idx = context.get("phase_index", 0)
+        total = context.get("phase_total", 0)
+        if phase_id and total:
+            header = f"Phase {idx}/{total}: {phase_id}"
+
+    target = agent or self._agent
+    agent_name = target.name if target else None
+
+    result = await self._show_agent_prompt(
+        title=f"[Advance check] {header}",
+        options=[
+            ("allow", "Advance to next phase"),
+            ("deny", "Stay on current phase"),
+        ],
+        subtitle=question,
+        agent=agent,
+        toast_message=(
+            f"Agent '{agent_name}' needs confirmation to advance"
+            if agent_name
+            else None
+        ),
+        toast_key=f"{target.id}:advance" if target else None,
+        post_deny_message=(
+            "Phase advance blocked. Agent will continue working on this phase."
+        ),
+    )
+    return result == "allow"
+```
+
+#### 4.5.d `_show_override_prompt` -- Refactor to thin caller for guardrail overrides
+
+**Before** (existing method, ~24 lines with emoji title and no agent awareness):
+```python
+async def _show_override_prompt(self, rule_id: str, description: str) -> bool:
+    ...
+    title = f"\U0001f6e1\ufe0f Override request: {rule_id}"
+    ...
+```
+
+**After** (thin caller over shared helper, ASCII title, agent-aware):
+```python
+async def _show_override_prompt(
+    self, rule_id: str, description: str, agent: Agent | None = None,
+) -> bool:
+    """Show override prompt for deny-level guardrail rules.
+
+    Thin caller over _show_agent_prompt with rule context formatting.
+    """
+    target = agent or self._agent
+    agent_name = target.name if target else None
+
+    result = await self._show_agent_prompt(
+        title=f"[Override] Rule: {rule_id}",
+        options=[
+            ("allow", "Allow -- approve this specific action"),
+            ("deny", "Deny -- block this action"),
+        ],
+        subtitle=description,
+        agent=agent,
+        toast_message=(
+            f"Agent '{agent_name}' needs override approval for {rule_id}"
+            if agent_name
+            else None
+        ),
+        toast_key=f"{target.id}:{rule_id}" if target else None,
+        post_deny_message="Override denied.",
+    )
+    return result == "allow"
+```
+
+**Key changes from current implementation:**
+- Emoji shield `\U0001f6e1\ufe0f` replaced with ASCII `[Override]` prefix.
+- New `agent` parameter (optional, backward compatible).
+- NEEDS_INPUT status + toast + restore all come for free from the shared helper.
+- The `description` string (already built by `request_override` MCP tool with
+  tool name, input, and blocking rule) becomes the subtitle.
+
+#### 4.5.e `_make_confirm_callback` -- Accept optional agent parameter
+
+**Before:**
+```python
+def _make_confirm_callback(self):
+    async def confirm(message: str) -> bool:
+        return await self._show_override_prompt("advance-check", message)
+    return confirm
+```
+
+**After:**
+```python
+def _make_confirm_callback(self, agent=None):
+    """Create async confirm callback for manual-confirm advance checks.
+
+    Args:
+        agent: The agent requesting confirmation. Used to set
+            NEEDS_INPUT status and show toast if not active.
+            If None, uses the currently active agent.
+    """
+    async def confirm(message: str, context: dict[str, Any] | None = None) -> bool:
+        return await self._show_advance_check_prompt(
+            message, context=context, agent=agent,
+        )
+    return confirm
+```
+
+#### 4.5.f `SelectionPrompt` subtitle support
+
+**What:** Add an optional `subtitle` parameter to `SelectionPrompt` that
+renders below the title and above the options.
+
+**File:** `widgets/prompts.py`
+
+In `SelectionPrompt.__init__`, add `subtitle: str | None = None` parameter.
+Store as `self.subtitle`.
+
+In `SelectionPrompt.compose`, after the title `Static`, conditionally yield:
+```python
+if self.subtitle:
+    yield Static(self.subtitle, classes="prompt-subtitle")
+```
+
+**CSS addition** in `styles.tcss`:
+```css
+.prompt-subtitle {
+    color: $text-muted;
+    padding: 0 0 1 0;
+}
+```
+
+---
+
+## 5. Edge Cases and Mitigations
+
+| Edge Case | Mitigation |
+|-----------|------------|
+| **Concurrent advance_phase calls** | `asyncio.Lock` in engine prevents double-prompt. Only one advance attempt at a time. |
+| **Agent closed while prompt is pending** | `_show_prompt` context manager's `finally` block already handles widget cleanup. The `finally` in `_show_agent_prompt` restores status. If agent is gone, the status set is a no-op. |
+| **No workflow engine active** | `advance_phase` MCP tool already returns error early. `_make_confirm_callback` with `context=None` still works (header falls back to generic text). |
+| **Stale phase data** | Phase context is read in `_run_single_check` at invocation time, not captured in a closure. |
+| **caller_name is None** | Both `_make_advance_phase(None)` and `_make_request_override(None)` produce callbacks with `agent=None`, which falls back to `self._agent` in `_show_agent_prompt`. |
+| **Prompt cancelled (Escape)** | `prompt.wait()` raises on cancel, caught by the `except` block in `_show_agent_prompt`, returns `None`. Callers treat `None` as deny. |
+| **Non-active agent prompt hidden** | Prompt gets `hidden` CSS class (existing behavior). Toast notification tells user which agent needs input. User switches manually. |
+| **Override prompt called without agent (backward compat)** | `_show_override_prompt` now has `agent=None` as default. Existing internal callers (if any) that don't pass `agent` still work -- falls back to `self._agent`. |
+| **Concurrent override + advance check** | These are independent flows on different agents. Each sets NEEDS_INPUT on its own agent. No lock needed between them -- the `_advance_lock` only serializes `attempt_phase_advance` calls. |
+| **Toast spam from override retry loops** | When an agent repeatedly hits the same deny rule, each `request_override` call fires a toast. The `toast_key` debounce in `_show_agent_prompt` suppresses repeat toasts within 10 seconds. Key format `"{agent_id}:{rule_id}"` ensures different rules and different agents get independent cooldowns. The prompt still mounts every time -- only the toast is suppressed. |
+| **Toast cooldown dict grows unbounded** | `_toast_timestamps` is a flat dict keyed by `"{agent_id}:{domain_id}"`. In practice this is bounded by (number of agents) x (number of rules + 1 advance key). No cleanup needed -- stale keys are harmless, timestamps just expire naturally. |
+
+---
+
+## 6. Testing Requirements
+
+### 6.1 Unit Tests (fast marker)
+
+| Test | Location | What It Verifies |
+|------|----------|------------------|
+| `test_manual_confirm_passes_context` | `tests/test_checks.py` | `ManualConfirm.check()` passes context dict to callback |
+| `test_manual_confirm_none_context` | `tests/test_checks.py` | `ManualConfirm.check()` works when context is None (backward compat) |
+| `test_engine_injects_phase_context` | `tests/test_engine.py` | `_run_single_check` for manual-confirm includes `phase_id`, `phase_index`, `phase_total`, `check_id` in params |
+| `test_advance_lock_prevents_concurrent` | `tests/test_engine.py` | Two concurrent `attempt_phase_advance` calls serialize (second waits for first) |
+| `test_should_show_toast_none_key` | `tests/test_app_ui.py` | `_should_show_toast(None)` always returns True (no debounce) |
+| `test_should_show_toast_cooldown` | `tests/test_app_ui.py` | Same key within 10s returns False; after 10s returns True (mock `time.monotonic`) |
+| `test_should_show_toast_independent_keys` | `tests/test_app_ui.py` | Different keys have independent cooldowns |
+
+### 6.2 Widget Tests (fast marker)
+
+| Test | Location | What It Verifies |
+|------|----------|------------------|
+| `test_selection_prompt_subtitle` | `tests/test_widgets.py` | `SelectionPrompt` with subtitle renders the subtitle text |
+| `test_selection_prompt_no_subtitle` | `tests/test_widgets.py` | `SelectionPrompt` without subtitle does not render subtitle element |
+
+### 6.3 Integration Tests (integration marker)
+
+| Test | Location | What It Verifies |
+|------|----------|------------------|
+| `test_advance_check_prompt_shows_phase_context` | `tests/test_app_ui.py` | Confirm prompt displays phase name and progress (e.g., "Phase 2/4: review") |
+| `test_advance_check_sets_needs_input` | `tests/test_app_ui.py` | Requesting agent gets `NEEDS_INPUT` status during prompt, restored after |
+| `test_advance_check_toast_for_inactive_agent` | `tests/test_app_ui.py` | Toast shown when advance check fires for a non-active agent |
+| `test_advance_check_deny_feedback` | `tests/test_app_ui.py` | Post-deny toast: "Phase advance blocked..." |
+| `test_advance_check_no_auto_switch` | `tests/test_app_ui.py` | Active agent does NOT change when another agent's advance check fires |
+| `test_override_prompt_shows_rule_context` | `tests/test_app_ui.py` | Override prompt displays `[Override] Rule: {rule_id}` title + tool/input as subtitle |
+| `test_override_prompt_sets_needs_input` | `tests/test_app_ui.py` | Requesting agent gets `NEEDS_INPUT` status during override prompt |
+| `test_override_prompt_toast_for_inactive_agent` | `tests/test_app_ui.py` | Toast shown when override fires for a non-active agent |
+| `test_override_prompt_no_emoji` | `tests/test_app_ui.py` | Override prompt title contains no non-ASCII characters |
+| `test_toast_debounce_suppresses_repeat` | `tests/test_app_ui.py` | Second override prompt for same agent+rule within 10s does NOT fire a toast (prompt still shows) |
+| `test_toast_debounce_allows_different_keys` | `tests/test_app_ui.py` | Two override prompts for same agent but different rule_ids both fire toasts (independent keys) |
+| `test_toast_debounce_expires_after_cooldown` | `tests/test_app_ui.py` | After 10s cooldown, same agent+rule fires toast again (mock `time.monotonic`) |
+
+### 6.4 Cross-Platform
+
+- No new non-ASCII characters. `[Advance check]` and `[Override]` prefixes
+  replace the existing shield emoji (`\U0001f6e1\ufe0f`).
+- No new file I/O paths (all changes are in-memory state and TUI rendering).
+- No new subprocess calls.
+
+---
+
+## 7. Dependency / Merge Order
+
+Changes should be implemented and reviewed in this order (each step builds on
+the previous):
+
+1. **`checks/protocol.py` + `checks/builtins.py`** -- Widen seam + update
+   ManualConfirm. Unit tests pass independently.
+2. **`workflows/engine.py`** -- Inject phase context + add lock. Engine tests
+   pass with mocked callback.
+3. **`widgets/prompts.py` + `styles.tcss`** -- Add subtitle support. Widget
+   tests pass independently.
+4. **`app.py`** -- New `_show_agent_prompt` shared helper +
+   `_show_advance_check_prompt` thin caller + refactored `_show_override_prompt`
+   thin caller + updated `_make_confirm_callback`. Integration tests pass.
+5. **`mcp.py`** -- Convert both `advance_phase` and `request_override` to
+   factories. Full flow works end-to-end.
+
+Steps 1-3 can be developed in parallel. Steps 4-5 depend on all prior steps.
+
+---
+
+## 8. Composability Invariants (Post-Implementation Checks)
+
+After implementation, verify these properties hold:
+
+- [ ] `checks/protocol.py` imports only from stdlib (leaf module boundary).
+- [ ] `checks/builtins.py` imports only from `checks/protocol` (leaf boundary).
+- [ ] `workflows/engine.py` does NOT import from `widgets/` or `app.py`.
+- [ ] `ManualConfirm` does NOT import from `claudechic.widgets` or `claudechic.app`.
+- [ ] `SelectionPrompt` does NOT import from `workflows/` or `checks/`.
+- [ ] The `AsyncConfirmCallback` type alias is the ONLY seam between engine and TUI.
+- [ ] `_show_agent_prompt` contains NO `if prompt_type` or `if context_type` branches.
+- [ ] Both `_show_advance_check_prompt` and `_show_override_prompt` are thin callers (under 25 lines each, no NEEDS_INPUT/toast/restore logic).
+- [ ] All existing tests pass without modification (backward compatibility).
+- [ ] No non-ASCII characters in any prompt title string.
+
+---
+
+See [SPEC_APPENDIX.md](SPEC_APPENDIX.md) for architectural decision rationale and implementation guardrails.

--- a/.project_team/advance_check_ux/SPEC_APPENDIX.md
+++ b/.project_team/advance_check_ux/SPEC_APPENDIX.md
@@ -1,0 +1,89 @@
+# SPEC Appendix: Advance Check UX
+
+**Parent:** [SPEC.md](SPEC.md)
+
+---
+
+## Appendix A: Architectural Decision -- Shared Helper, Not Three Methods
+
+### The Question
+
+Both advance check confirm prompts and guardrail override prompts need the same
+UX treatment (context header, NEEDS_INPUT, toast, status restore). Three options:
+
+| Option | Description | Verdict |
+|--------|-------------|---------|
+| A. Three methods | `_show_override_prompt` (existing) + `_show_advance_check_prompt` (new) + `_show_guardrail_override_prompt` (new) | **Reject.** Duplicates NEEDS_INPUT/toast/restore logic in 2+ places. Violates DRY and the algebraic principle. |
+| B. Refactor in place | Modify existing `_show_override_prompt` to handle both flows | **Reject.** The method would need `if prompt_type == ...` branches -- profile-as-code-switch smell. |
+| C. Extract shared law | One `_show_agent_prompt()` helper with the shared UX pattern. Two thin callers pass different parameters. | **Accept.** The shared behavior IS the compositional law. Callers are parameter presets, not code branches. |
+
+### Why Option C
+
+The shared UX pattern (mount prompt, set NEEDS_INPUT, toast, restore) is the
+**compositional law** for all "agent needs user approval" interactions. The
+differences between advance checks and guardrail overrides are just parameters:
+
+| Parameter | Advance Check | Guardrail Override |
+|-----------|--------------|-------------------|
+| Title prefix | `[Advance check]` | `[Override]` |
+| Header | `Phase 2/4: review` | `Rule: no_pip_install` |
+| Subtitle | Check question from YAML | Tool + input that was blocked |
+| Option labels | Advance / Stay | Allow / Deny |
+| Toast key | `{agent_id}:advance` | `{agent_id}:{rule_id}` |
+| Post-deny toast | "Phase advance blocked..." | "Override denied." |
+
+Same code path, different parameters. No `if` branches on prompt type.
+
+### Axis Impact
+
+No new axes. The "Prompt Rendering" axis gains a second value (override prompt)
+alongside the existing confirm prompt value. The `_show_agent_prompt()` helper
+IS the law that governs this axis -- if you follow the law (provide title,
+options, subtitle, agent), the UX works automatically. Adding a third prompt
+type in the future = just a new caller.
+
+---
+
+## Appendix B: Implementation Guardrails
+
+These rules prevent common mistakes during implementation.
+
+1. **DO NOT auto-switch the active agent tab.** The user controls focus. Use
+   the orange indicator + toast instead. Auto-switching while the user is
+   mid-thought in another agent is disruptive.
+
+2. **DO NOT use emoji in prompt titles.** The existing override prompt uses
+   a shield emoji -- both prompts must use ASCII only per cross-platform rules.
+   Use `[Advance check]` and `[Override]` prefixes.
+
+3. **DO NOT add `if prompt_type == ...` branches in the shared helper.** The
+   `_show_agent_prompt()` method must be prompt-type-agnostic. All differences
+   are expressed as parameters by the thin callers. If you find yourself
+   branching on the prompt type in the helper, the parameters are wrong.
+
+4. **DO NOT add a dataclass/named type for the context dict in
+   `protocol.py`.** The checks module is a leaf module (stdlib only). A plain
+   `dict[str, Any] | None` keeps the import boundary clean. The dict's keys
+   are documented in the docstring.
+
+5. **DO NOT capture phase info in a closure.** Read `self._current_phase` and
+   `self._phase_order` inside `_run_single_check` at execution time. Closures
+   over phase state go stale if another advance completes between callback
+   creation and invocation.
+
+6. **DO NOT gate sidebar updates on the active agent.** The `AgentItem`
+   reactive watcher already updates regardless of which agent is active. Do not
+   add conditional logic around status rendering.
+
+7. **DO NOT use `on_blur` refocusing.** No automatic cursor/focus movement
+   when a prompt appears. The prompt mounts where it mounts; the user navigates
+   to it via the sidebar or keyboard shortcut.
+
+8. **DO NOT create separate NEEDS_INPUT/toast/restore logic for each prompt
+   type.** That is exactly what `_show_agent_prompt()` exists to prevent. If
+   a future prompt type needs agent awareness, it calls the same helper.
+
+9. **DO NOT debounce in the thin callers.** Toast debounce is part of the
+   shared UX law in `_show_agent_prompt`. Callers pass a `toast_key` and the
+   helper handles cooldown. If a caller passes `toast_key=None`, no debounce
+   is applied -- that is the caller's choice, not the helper's decision.

--- a/.project_team/advance_check_ux/STATUS.md
+++ b/.project_team/advance_check_ux/STATUS.md
@@ -1,0 +1,19 @@
+# Project: advance_check_ux
+# Phase: setup
+# Issue: #21 - Advance check UX: show context and auto-focus agent
+
+## Vision
+Improve the advance-check UX in claudechic's TUI so that `manual-confirm` prompts show phase context and automatically draw the user's attention.
+
+## Two Deliverables
+1. Show phase context (e.g., "Phase 3/6: cluster-setup:ssh-config") above manual-confirm prompts
+2. Visual indicator / auto-focus when an agent's advance check is pending user input
+
+## Status
+- [x] Vision approved
+- [x] Setup initialized
+- [ ] Leadership spawned
+- [ ] Specification complete
+- [ ] Implementation complete
+- [ ] Tests passing
+- [ ] Sign-off

--- a/.project_team/advance_check_ux/userprompt.md
+++ b/.project_team/advance_check_ux/userprompt.md
@@ -1,0 +1,17 @@
+# User Prompt
+
+GitHub Issue #21: Advance check UX: show context and auto-focus agent
+
+## Problem
+The advance check confirmation prompt in the TUI has two UX issues:
+
+1. **No context shown with the prompt** - When a manual-confirm advance check fires, the user sees the question but cannot see which workflow phase they're in or why they're being asked.
+
+2. **No auto-focus when confirmation is needed** - If the user is viewing a different agent's tab, they have no indication another agent is waiting for confirmation.
+
+## Expected Behavior
+1. Show phase name/hint alongside the confirmation prompt (e.g., "Phase X/N: <phase hint>")
+2. Auto-switch to agent's view if user is idle, or show a tab badge/notification
+
+## Context
+Found during cluster-setup workflow with 6 phases and frequent agent switching.

--- a/.project_team/interrupt_agent/SPEC.md
+++ b/.project_team/interrupt_agent/SPEC.md
@@ -1,0 +1,311 @@
+# Specification: `interrupt_agent` MCP Tool
+
+**Issue:** GitHub #10
+**Status:** Approved by Leadership team
+**Target:** `submodules/claudechic/claudechic/mcp.py`
+
+---
+
+## 1. Tool Signature
+
+```python
+@tool(
+    "interrupt_agent",
+    "Interrupt another agent's current task and optionally redirect it with a new prompt. "
+    "Awaits the interrupt to completion before sending any redirect.",
+    {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Name of the agent to interrupt",
+            },
+            "prompt": {
+                "type": "string",
+                "description": "New prompt to send after interrupting (optional)",
+            },
+        },
+        "required": ["name"],
+    },
+)
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | `str` | yes | Target agent name (resolved via `_find_agent_by_name`) |
+| `prompt` | `str` | no | New prompt to send after interrupt completes |
+
+**Terminology (from TerminologyGuardian):**
+- Parameter is `prompt` (not `message`, `instruction`, or `redirect`)
+- Tool name is `interrupt_agent` (not `stop_agent`, `cancel_agent`, `kill_agent`)
+- Matches `ask_agent` / `tell_agent` naming convention: `<verb>_agent`
+
+---
+
+## 2. Behavior Matrix (Crystal)
+
+All four combinations of agent state x redirect are handled:
+
+| Agent State | `prompt` provided? | Behavior | Return message |
+|-------------|-------------------|----------|----------------|
+| `busy` | no | Await `agent.interrupt()`, return | `"Interrupted '<name>'"` |
+| `busy` | yes | Await `agent.interrupt()`, then `await agent.send(prompt)` | `"Interrupted '<name>' and sent new prompt"` |
+| `idle` | no | No-op | `"Agent '<name>' is not currently busy"` |
+| `idle` | yes | Skip interrupt, send prompt directly via `_send_prompt_fire_and_forget` | `"Agent '<name>' was idle; sent new prompt"` |
+
+**Key design:** The idle+prompt case uses `_send_prompt_fire_and_forget` (non-blocking) because there is no interrupt to sequence against. The busy+prompt case uses `await agent.send()` directly to guarantee ordering: interrupt completes before redirect is dispatched.
+
+---
+
+## 3. Error Cases
+
+| Condition | Return | isError |
+|-----------|--------|---------|
+| `_app` or `_app.agent_mgr` is None | `"App not initialized"` | yes |
+| Agent name not found | `"Agent '<name>' not found"` (or similar from `_find_agent_by_name`) | yes |
+| Agent name matches caller | `"An agent cannot interrupt itself"` | yes |
+| `interrupt()` raises exception | `"Failed to interrupt '<name>': <error>"` | yes |
+| `send()` raises after interrupt | `"Interrupted '<name>' but failed to send new prompt: <error>"` | yes |
+
+The last two cases use a try/except around the await calls. If interrupt fails, the redirect is NOT attempted (fail-fast). If interrupt succeeds but redirect fails, the caller is told the interrupt worked but the redirect did not.
+
+---
+
+## 4. Implementation Approach
+
+### 4.1 Factory Function
+
+Follow the `_make_close_agent` pattern (mcp.py lines 600-642) since it also uses `await` (not fire-and-forget):
+
+```python
+def _make_interrupt_agent(caller_name: str | None = None):
+    """Create interrupt_agent tool with caller name bound."""
+
+    @tool(
+        "interrupt_agent",
+        "Interrupt another agent's current task and optionally redirect it "
+        "with a new prompt. Awaits the interrupt to completion before sending "
+        "any redirect.",
+        {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the agent to interrupt",
+                },
+                "prompt": {
+                    "type": "string",
+                    "description": "New prompt to send after interrupting (optional)",
+                },
+            },
+            "required": ["name"],
+        },
+    )
+    async def interrupt_agent(args: dict[str, Any]) -> dict[str, Any]:
+        """Interrupt an agent, optionally redirecting with a new prompt."""
+        try:
+            if _app is None or _app.agent_mgr is None:
+                return _error_response("App not initialized")
+            _track_mcp_tool("interrupt_agent")
+
+            name = args["name"]
+            prompt = args.get("prompt")
+
+            # Self-interrupt prevention
+            if caller_name and name == caller_name:
+                return _error_response("An agent cannot interrupt itself")
+
+            agent, error = _find_agent_by_name(name)
+            if agent is None:
+                return _error_response(error or "Agent not found")
+
+            # Idle agent: skip interrupt, optionally send prompt
+            if agent.status != "busy":
+                if prompt:
+                    _send_prompt_fire_and_forget(
+                        agent, prompt, caller_name=caller_name
+                    )
+                    return _text_response(
+                        f"Agent '{name}' was idle; sent new prompt"
+                    )
+                return _text_response(
+                    f"Agent '{name}' is not currently busy"
+                )
+
+            # Busy agent: await interrupt to completion
+            try:
+                await agent.interrupt()
+            except Exception as exc:
+                log.exception(f"interrupt_agent: interrupt failed for '{name}'")
+                return _error_response(
+                    f"Failed to interrupt '{name}': {exc}"
+                )
+
+            # Redirect with new prompt if provided
+            if prompt:
+                try:
+                    wrapped = prompt
+                    if caller_name:
+                        wrapped = (
+                            f"[Redirected by agent '{caller_name}']\n\n"
+                            f"{prompt}"
+                        )
+                    await agent.send(wrapped)
+                except Exception as exc:
+                    log.exception(
+                        f"interrupt_agent: redirect failed for '{name}'"
+                    )
+                    return _error_response(
+                        f"Interrupted '{name}' but failed to send "
+                        f"new prompt: {exc}"
+                    )
+                return _text_response(
+                    f"Interrupted '{name}' and sent new prompt"
+                )
+
+            return _text_response(f"Interrupted '{name}'")
+
+        except Exception as exc:
+            log.exception(f"interrupt_agent failed for '{args.get('name', 'unknown')}'")
+            return _error_response(
+                f"Failed to interrupt '{args.get('name', 'unknown')}': {exc}"
+            )
+
+    return interrupt_agent
+```
+
+### 4.2 Call Sequence (busy + redirect)
+
+```
+interrupt_agent(name="Researcher", prompt="Focus on section 3 instead")
+  |
+  +-- _find_agent_by_name("Researcher") -> agent
+  +-- check agent.status == "busy"
+  +-- await agent.interrupt()
+  |     |-- SDK interrupt (up to 5s)
+  |     |-- Wait for task completion (up to 3s)
+  |     |-- State -> IDLE, observer.on_complete()
+  |     +-- Drain any pre-existing pending messages
+  +-- await agent.send("[Redirected by ...]\n\nFocus on section 3 instead")
+  |     |-- agent is IDLE now, so send() calls _start_response() immediately
+  |     +-- Agent begins processing new prompt
+  +-- return "Interrupted 'Researcher' and sent new prompt"
+```
+
+### 4.3 Registration
+
+In `create_chic_server()` (mcp.py line 934-947), add after `close_agent`:
+
+```python
+tools = [
+    _make_spawn_agent(caller_name),
+    _make_spawn_worktree(caller_name),
+    _make_ask_agent(caller_name),
+    _make_tell_agent(caller_name),
+    _make_whoami(caller_name),
+    list_agents,
+    _make_close_agent(caller_name),
+    _make_interrupt_agent(caller_name),  # <-- NEW
+    # Workflow guidance tools
+    advance_phase,
+    get_phase,
+    request_override,
+    acknowledge_warning,
+]
+```
+
+### 4.4 Module Docstring Update
+
+Update the docstring at mcp.py line 1-11 to include `interrupt_agent`:
+
+```python
+"""In-process MCP server for claudechic agent control.
+
+Exposes tools for Claude to manage agents within claudechic:
+- spawn_agent: Create new agent, optionally with initial prompt
+- spawn_worktree: Create git worktree + agent
+- ask_agent: Send question to existing agent (expects reply)
+- tell_agent: Send message to existing agent (no reply expected)
+- interrupt_agent: Interrupt an agent, optionally redirect with new prompt
+- list_agents: List current agents and their status
+- close_agent: Close an agent by name
+- finish_worktree: Finish current agent's worktree (commit, rebase, merge, cleanup)
+"""
+```
+
+---
+
+## 5. Risk Mitigations
+
+| # | Risk | Severity | Mitigation |
+|---|------|----------|------------|
+| 1 | No lock on `interrupt()` -- concurrent calls could race | Medium | Check `agent.status != "busy"` before calling. If status changes between check and await, `interrupt()` is idempotent (INTERRUPTED -> IDLE is valid; IDLE -> IDLE is a no-op in `_set_response_state`) |
+| 2 | Interrupting idle agent | Low | Explicit status check with distinct return messages per the behavior matrix |
+| 3 | Redirect lost on process death | High | `await agent.interrupt()` completes (or raises) before redirect is attempted. If interrupt fails, redirect is skipped and error is returned |
+| 4 | Windows hard-kill vs Unix SIGINT | Medium | No new mitigation needed -- `_sigint_fallback()` already handles platform differences (agent.py lines 618-657). The sequencing fix (await before redirect) covers both platforms |
+| 5 | Infinite interrupt loops | Medium | Self-interrupt banned via `caller_name` check. Rate limiting deferred to future work if needed (same pattern as other MCP tools) |
+| 6 | Mid-tool-call interrupt | Low | Document-only: same behavior as Escape key. SDK handles mid-tool gracefully. No new code needed |
+| 7 | MCP handler timeout from await | Medium | Worst case is ~8s (5s SDK timeout + 3s task wait). User explicitly chose robustness over responsiveness. `close_agent` already uses direct await as precedent |
+
+---
+
+## 6. TUI Notification
+
+When an agent is interrupted via this tool, the TUI should show a notification toast. The existing `agent.interrupt()` flow triggers `observer.on_complete()` which updates the sidebar status indicator (busy -> idle).
+
+**Additional notification:** The calling context in `app.py`'s `action_escape` shows `self.notify("Interrupted")`. For MCP-triggered interrupts, the notification happens naturally through the observer pattern -- `on_complete` posts `ResponseComplete` which the UI handles.
+
+**Redirect prefix:** When a prompt includes a redirect, the message is prefixed with `[Redirected by agent '<caller_name>']` so the target agent understands the context change. This mirrors the existing patterns:
+- `tell_agent`: `[Message from agent '<caller_name>']`
+- `ask_agent`: `[Question from agent '<caller_name>' - please respond back...]`
+- `spawn_agent`: `[Spawned by agent '<caller_name>']`
+
+---
+
+## 7. File Locations
+
+| What | Where |
+|------|-------|
+| New factory function `_make_interrupt_agent` | `mcp.py`, after `_make_close_agent` (~line 643) |
+| Registration in `create_chic_server` | `mcp.py` line 941, after `_make_close_agent(caller_name)` |
+| Module docstring update | `mcp.py` lines 1-11 |
+| No changes needed | `agent.py` (reuse existing `interrupt()` as-is) |
+| No changes needed | `app.py` (observer pattern handles UI updates) |
+| Tests | New file: `tests/test_mcp_interrupt_agent.py` |
+
+---
+
+## 8. Test Plan
+
+### Unit Tests (in `tests/test_mcp_interrupt_agent.py`)
+
+1. **Busy agent, no redirect:** Verify `interrupt()` is called, return message confirms interruption
+2. **Busy agent, with redirect:** Verify `interrupt()` then `send()` called in order, return message confirms both
+3. **Idle agent, no redirect:** Verify `interrupt()` NOT called, return message says "not busy"
+4. **Idle agent, with redirect:** Verify `interrupt()` NOT called, `_send_prompt_fire_and_forget` called, return message says "idle; sent new prompt"
+5. **Self-interrupt prevention:** Verify error when `caller_name == name`
+6. **Agent not found:** Verify error for non-existent agent name
+7. **Interrupt failure:** Mock `interrupt()` to raise, verify error returned and `send()` NOT called
+8. **Redirect failure:** Mock `send()` to raise after successful interrupt, verify partial-success error
+9. **Redirect prefix:** Verify `[Redirected by agent '...']` prefix is applied when `caller_name` is set
+
+### Integration Tests (marked `@pytest.mark.integration`)
+
+10. **Full flow with mock SDK:** Create two agents, have one interrupt the other mid-response, verify state transitions
+
+---
+
+## 9. Composability Verification
+
+**Axes:** Target resolution x Interrupt mechanism x Redirect -- all orthogonal.
+
+**Seam check (swap test):**
+- Swap interrupt mechanism -> tool calls `agent.interrupt()`, no internal knowledge
+- Swap messaging mechanism -> tool calls `agent.send()` / `_send_prompt_fire_and_forget`, no internal knowledge
+- Interrupt does not know about redirect; redirect does not know about interrupt internals
+
+**Crystal:** 4 points (busy/idle x redirect/no-redirect), all handled with distinct code paths and return messages. No holes.
+
+**Algebraic composition:** Both interrupt and send follow their own protocols. The tool sequences them; it does not merge them. Adding new agent states or new post-interrupt actions would not require changing the interrupt mechanism.

--- a/.project_team/interrupt_agent/STATUS.md
+++ b/.project_team/interrupt_agent/STATUS.md
@@ -1,0 +1,43 @@
+# interrupt_agent
+
+## Vision
+Add an `interrupt_agent` MCP tool that lets one agent interrupt another mid-task and optionally redirect it with a new prompt. Implements GitHub Issue #10.
+
+## Status: SIGN-OFF (APPROVED)
+- All 6 agents confirmed READY
+- 724 tests passed, 0 regressions
+- Phase: sign-off (project-team workflow)
+
+## Commit Plan
+### Step 1: Claudechic submodule (commit to main)
+- Branch: fix/code-quality-audit-cleanup -> merge into main
+- Files: mcp.py, test_mcp_interrupt_agent.py, test_autocomplete.py, test_hints_integration.py, pyproject.toml, analytics.md, CLAUDE.md
+
+### Step 2: Parent repo (commit to develop, then merge to main)
+- Branch: develop -> merge into main
+- Files: docs/getting-started.md, template/CLAUDE.md.jinja, submodule pointer
+- .project_team/interrupt_agent/ stays on develop only (blocked on main by pre-commit hook)
+
+## Files Changed
+
+### submodules/claudechic/
+- claudechic/mcp.py -- interrupt_agent tool (~80 lines, factory pattern)
+- tests/test_mcp_interrupt_agent.py -- 11 tests (NEW)
+- tests/test_autocomplete.py -- fixed pre-existing fuzzy match failures
+- tests/test_hints_integration.py -- fixed pre-existing broken hints test
+- pyproject.toml -- registered integration marker
+- .ai-docs/analytics.md -- added interrupt_agent to tracked tools
+- CLAUDE.md -- added Inter-Agent Communication section
+
+### Parent repo
+- docs/getting-started.md -- added interrupt_agent to MCP tools list
+- template/CLAUDE.md.jinja -- added Inter-Agent Communication section
+- .project_team/interrupt_agent/ -- project state (develop only)
+
+## Agents
+- Composability: READY
+- Terminology: READY
+- Skeptic: READY
+- UserAlignment: READY
+- Implementer: READY
+- TestEngineer: READY

--- a/.project_team/interrupt_agent/userprompt.md
+++ b/.project_team/interrupt_agent/userprompt.md
@@ -1,0 +1,16 @@
+# User Prompt
+
+Add an `interrupt_agent` MCP tool for inter-agent interruption (GitHub Issue #10).
+
+## Requirements (from issue)
+1. Calls the existing `agent.interrupt()` method (SDK interrupt + SIGINT fallback)
+2. Optionally accepts a follow-up message/prompt to queue after the interrupt
+3. Returns confirmation that the interrupt was delivered
+4. If `message` is provided, it's queued as the next prompt (agent resumes with new instructions)
+5. If no `message`, agent simply stops and becomes idle
+
+## Existing Infrastructure
+- `agent.interrupt()` in `agent.py` -- handles SDK interrupt, SIGINT fallback, task cancellation
+- `client.interrupt()` in the SDK -- non-blocking interrupt support
+- Escape key handler in `app.py` already orchestrates this flow
+- `tell_agent` and `close_agent` MCP tools already exist as patterns to follow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ pytest tests/test_copier_generation.py -v  # After template changes
 ## Project Layout
 
 - `template/` -- Jinja2 source files processed by Copier (*.jinja files). This is what end users get.
-- `submodules/claudechic/` -- Core TUI + engine. Separate git repo, editable install. Changes need own commits + parent pointer update.
+- `submodules/claudechic/` -- Core TUI + engine. Separate git repo, editable install. When you change files here: (1) commit inside the submodule, (2) `git push origin main` inside the submodule, (3) commit the updated submodule pointer in the parent repo. CI cannot fetch submodule commits that only exist locally.
 - `workflows/` -- Workflow definitions for THIS repo's development (project_team, tutorial, etc.)
 - `global/` -- Always-active guardrail rules (rules.yaml) and contextual hints (hints.yaml).
 - `.claude/rules/` -- Agent context files documenting claudechic internals (developer mode only).

--- a/pixi.lock
+++ b/pixi.lock
@@ -1734,8 +1734,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./submodules/claudechic
   name: claudechic
-  version: 0.1.dev667+g612c42d83
-  sha256: e08d9b87da8b35fce8b2eb6301e3ddda5586188b33f3eb67b2ac5b50fd196b7b
+  version: 0.1.dev689+g9fb6f0c26.d20260413
+  sha256: b7a6a299ef6282b5a4ce7be7a75adb6a16d0aea866e2181ac7553ff4fa3643c0
   requires_dist:
   - aiofiles>=25.1.0
   - aiohttp>=3.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ testpaths = ["tests", "submodules/claudechic/tests"]
 markers = [
     "slow: tests that take >30s (copier+pixi install, E2E, pexpect)",
     "integration: tests requiring external tools (copier, pixi) but <60s each",
+    "fast: fast unit tests (default tier, under 1s each)",
     "copier: tests that run copier copy",
     "pixi: tests that require pixi installed",
     "network: tests requiring network access",


### PR DESCRIPTION
## Summary
- **Phase context in advance check prompts** — `[Advance check] Phase 2/4: review` header with question subtitle
- **Rule context in override prompts** — `[Override] Rule: no_pip_install` header, ASCII-only (emoji removed)
- **NEEDS_INPUT status** — orange sidebar dot on requesting agent while approval prompt is waiting
- **Toast notifications** — non-disruptive toast for non-active agents, debounced per agent+rule (10s cooldown)
- **Focus bug fix** — pre-existing bug where prompts were unfocusable after agent switch (TDD verified: red then green)

## Architecture
Shared `_show_agent_prompt()` helper (the compositional law) with two thin callers:
- `_show_advance_check_prompt()` — phase context formatting
- `_show_override_prompt()` — rule context formatting (refactored)

Widened `AsyncConfirmCallback` seam with optional context dict. Both `advance_phase` and `request_override` MCP tools converted to factories with caller agent binding.

## Files changed (claudechic submodule)
- `checks/protocol.py` — widen callback seam
- `checks/builtins.py` — ManualConfirm forwards context
- `workflows/engine.py` — phase context injection + asyncio.Lock
- `app.py` — shared helper, thin callers, toast debounce, focus fix
- `mcp.py` — factory conversions for both MCP tools
- `widgets/prompts.py` + `styles.tcss` — SelectionPrompt subtitle support

## Test plan
- [x] 23 new tests (7 unit, 2 widget, 12 integration, 2 TDD regression)
- [x] 674 total pass, 0 failures (1 pre-existing flaky, unrelated)
- [x] TDD verified: focus bug tests red before fix, green after
- [x] Manual testing: advance check prompt with phase context confirmed working
- [x] Manual testing: override prompt with rule context confirmed working
- [x] Manual testing: orange dot and toast visible from non-active agent tab
- [x] CI: trigger long/integration test suite

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)