### PR TITLE
fix: sub-agent phase injection + workflow rules (#37)

### DIFF
--- a/.claude/rules/hints-system.md
+++ b/.claude/rules/hints-system.md
@@ -9,16 +9,96 @@ paths:
 
 LEAF MODULE: imports only stdlib. Never import from workflows/, checks/, or guardrails/.
 
-## Pipeline
+## Two Patterns for Hints
 
-The hints engine runs a 6-stage pipeline: activation → trigger → lifecycle → sort → budget → present.
+claudechic has two distinct patterns for showing hints to users. Choose the right one based on what triggers the hint.
 
-1. **Activation** — cheapest gate, dict lookup via `ActivationConfig.is_active(hint_id)`.
-2. **Trigger** — call `trigger.check(state)` wrapped in try-except (IRON RULE: never crash for a hint).
-3. **Lifecycle** — stateful history check via `HintLifecycle.should_show(hint_id, state_store)`.
-4. **Sort** — priority ASC, last_shown_ts ASC (None→0), definition_order ASC.
-5. **Budget** — take top N candidates (default 2 per evaluation cycle).
-6. **Present** — resolve dynamic messages, schedule toasts with delays, call `lifecycle.record_shown()`.
+### Pattern 1: Pipeline Hints (YAML-defined)
+
+For hints triggered by **project disk state** -- files existing, config values, workflow phase, etc.
+
+- Defined in `global/hints.yaml` or workflow manifests
+- Evaluated by the 6-stage pipeline at startup, workflow activation/deactivation
+- Triggered by `TriggerCondition.check(ProjectState)` -- a frozen snapshot of disk/config state
+- Lifecycle managed by pipeline (`ShowOnce`, `CooldownPeriod`, etc.)
+- Respects `/hints off` activation gate
+- All existing YAML hints use `AlwaysTrue` trigger + `show-once` lifecycle (rotating tip pool)
+
+**When to use:** The hint's relevance can be determined from disk state (files, config, phase). The hint is not time-sensitive -- showing it a few seconds after startup is fine.
+
+### Pattern 2: Event-Driven Hints (code-defined)
+
+For hints triggered by **live UI events** -- agent count changes, first sidebar mount, widget interactions, etc.
+
+- Defined inline in the relevant `app.py` handler (e.g., `on_agent_created`)
+- Triggered by a specific code path, not the pipeline
+- Uses direct `app.notify()` for display
+- Uses `HintStateStore` for cross-session persistence (optional)
+- Does NOT go through the pipeline, does NOT appear in hints.yaml
+- NOT affected by `/hints off` (they're direct notifications)
+
+**When to use:** The hint responds to a live UI event that `ProjectState` doesn't capture (agent spawned, widget clicked for the first time, etc.). The hint must appear at a precise moment.
+
+**Implementation pattern:**
+
+```python
+# In the relevant app.py handler:
+def on_agent_created(self, agent):
+    # ... existing code ...
+
+    # Event-driven hint: show once ever when agent count first reaches 2
+    if len(self.agent_mgr.agents) == 2:
+        from claudechic.hints.state import HintStateStore
+
+        store = HintStateStore(self._cwd)
+        hint_id = "event:agent-switcher-tip"
+        if store.get_times_shown(hint_id) == 0:
+            self.notify(
+                "Tip: Use Ctrl+1-9 to switch agents, "
+                "or click them in the sidebar.",
+                severity="information",
+                timeout=8,
+            )
+            store.increment_shown(hint_id)
+            store.save()
+```
+
+**Key rules for event-driven hints:**
+- Guard with `HintStateStore.get_times_shown() == 0` for show-once behavior
+- Always call `store.save()` after mutation (atomic write to `.claude/hints_state.json`)
+- Keep the hint logic in the handler where the event occurs -- don't scatter it
+- Use `event:` prefix in hint IDs to distinguish from pipeline hints (see naming below)
+
+**Naming convention for HintStateStore keys:**
+- Pipeline hints: `namespace:bare-id` (e.g., `global:tip_worktree`) -- auto-qualified by parser
+- Event-driven hints: `event:descriptive-name` (e.g., `event:agent-switcher-tip`) -- manually set in code
+- The `event:` prefix prevents collisions with YAML-defined hint IDs and makes grep easy
+
+**Grandfathered exception:** The existing key `"agent-switcher-tip"` in `app.py` predates this convention and does not carry the `event:` prefix. Do not rename it -- the key is persisted in `.claude/hints_state.json` on user machines and renaming would reset shown-state for existing users. All new event-driven hint IDs should follow the `event:` prefix convention.
+
+**Where event-driven hints live in code:**
+- In the app.py handler that detects the event (e.g., `on_agent_created`, `on_agent_switched`)
+- NOT in `hints/` module (that's the pipeline system)
+- NOT in `global/hints.yaml` (that's for pipeline hints)
+
+## Pipeline Details
+
+The hints engine runs a 6-stage pipeline: activation -> trigger -> lifecycle -> sort -> budget -> present.
+
+1. **Activation** -- cheapest gate, dict lookup via `ActivationConfig.is_active(hint_id)`.
+2. **Trigger** -- call `trigger.check(state)` wrapped in try-except (IRON RULE: never crash for a hint).
+3. **Lifecycle** -- stateful history check via `HintLifecycle.should_show(hint_id, state_store)`.
+4. **Sort** -- priority ASC, last_shown_ts ASC (None->0), definition_order ASC.
+5. **Budget** -- take top N candidates (default 2 per evaluation cycle).
+6. **Present** -- resolve dynamic messages, schedule toasts with delays, call `lifecycle.record_shown()`.
+
+### Pipeline Evaluation Points
+
+| Trigger Point | Budget | Timing |
+|---|---|---|
+| App startup (`on_mount`) | 2 toasts | 2s initial delay, 6s gap |
+| Workflow activation | 2 toasts | 5s gap (non-startup) |
+| Workflow deactivation | 1 toast | 5s gap (non-startup) |
 
 ## Extension Points
 
@@ -28,9 +108,10 @@ The hints engine runs a 6-stage pipeline: activation → trigger → lifecycle �
 
 ## Key Types
 
-- `HintSpec` — frozen dataclass binding trigger + lifecycle + message + severity + priority. This is the pipeline input.
-- `HintDecl` — YAML declaration parsed from manifests. Converted to `HintSpec` via adapter.
-- `HintRecord` — pipeline output, ready for presentation. Carries resolved message + severity + priority.
+- `HintSpec` -- frozen dataclass binding trigger + lifecycle + message + severity + priority. This is the pipeline input.
+- `HintDecl` -- YAML declaration parsed from manifests. Converted to `HintSpec` via adapter.
+- `HintRecord` -- pipeline output, ready for presentation. Carries resolved message + severity + priority.
+- `ProjectState` -- frozen snapshot passed to triggers. Contains: `root`, `copier` (CopierAnswers), `session_count`, `current_phase`. Also exposes filesystem primitives: `path_exists()`, `dir_is_empty()`, `file_contains()`, `count_files_matching()`.
 
 ## YAML ID Rules
 
@@ -40,10 +121,12 @@ Use bare names only in YAML (no colons). The parser qualifies IDs as `namespace:
 
 State persists to `.claude/hints_state.json`. Only `HintStateStore` reads/writes this file. Graceful degradation: missing or corrupt file = fresh start. Atomic writes via temp-then-rename.
 
+Both pipeline hints and event-driven hints share the same state file. The `event:` prefix on event-driven hint IDs prevents collisions.
+
 ## Severity Levels
 
-- `info` (default) — 7s toast timeout, maps to Textual "information" severity.
-- `warning` — 10s toast timeout, maps to Textual "warning" severity.
+- `info` (default) -- 7s toast timeout, maps to Textual "information" severity.
+- `warning` -- 10s toast timeout, maps to Textual "warning" severity.
 
 **Freshness:** If you modify source files matched by this rule, verify this
 document still accurately describes the system behavior. Update if needed.

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ __pycache__/
 
 # Audit workflow database (generated per-user at runtime)
 .audit/
+scripts/audit/*.db
 
 # Test artifacts
 .test_runs/

--- a/.project_team/backend_decoupling/SPEC.md
+++ b/.project_team/backend_decoupling/SPEC.md
@@ -1,0 +1,2009 @@
+# Backend Decoupling Specification
+
+**Project:** backend_decoupling
+**Status:** Phase 1 Specification (Approved Approach A: pydantic-ai as engine)
+**Date:** 2026-04-11
+**Authors:** Composability, Skeptic, Terminology, Researcher, UserAlignment agents
+**Amended:** 2026-04-11 — Fresh review findings incorporated (see Amendment Log)
+
+---
+
+## 1. Overview
+
+### Goal
+
+Decouple the claudechic workflow engine from the Claude Code API so it can run
+on alternative AI backends. This extends claudechic's audience beyond Claude Code
+users, making the workflow/phase/guardrails system available to anyone using
+OpenAI, Gemini, Mistral, Ollama, or other LLM providers.
+
+### Scope (Phase 1)
+
+- Define an `AgentBackend` protocol that abstracts the LLM connection
+- Extract the existing Claude Code SDK usage into a `ClaudeCodeBackend` adapter
+- Implement a `PydanticAIBackend` adapter using pydantic-ai's `Agent.iter()` API
+- Implement 7 core file/system tools for non-Claude-Code backends
+- Bridge claudechic's orchestration tools (spawn_agent, tell_agent, etc.) to
+  pydantic-ai's function-calling interface
+- Integrate claudechic's guardrails with pydantic-ai's hook system
+- Integrate interactive tool permissions with pydantic-ai's hook system
+
+### Non-Goals (Phase 1)
+
+- Session resume for pydantic-ai backend
+- Context compaction (`/compact`) for pydantic-ai backend
+- File checkpointing / `/rewind`
+- Permission mode cycling (default/auto-edit/plan)
+- Implementing all Claude Code tools (WebSearch, WebFetch, NotebookEdit, etc.)
+- MCP server mode for Cursor/Cline integration
+- Agent-to-Agent (A2A) protocol support
+
+### Decision
+
+**pydantic-ai (core, maintained by the Pydantic team) is the backend engine.**
+
+- pydantic-ai v1.80.0+, released 2026-04-10, actively maintained
+- Provides 15+ model providers: OpenAI, Anthropic, Gemini, Groq, Mistral,
+  Ollama, Bedrock, Cohere, HuggingFace, OpenRouter, xAI, Cerebras, Outlines
+- **NOT** using pydantic-ai-backend (vstorm-co community package) — we implement
+  our own file tools to avoid dependency on a community-maintained project
+
+**Implementation timing:** Wait 2-4 weeks after v1.80.0 release before starting
+implementation, to allow early-adopter bug reports to surface. Add weekly CI job
+running against latest pydantic-ai to detect breakage early.
+
+### Backward Compatibility Guarantee
+
+- `claude-code` remains the **default backend** when no `--backend` flag is set
+- Zero behavior change for existing users
+- The Claude Code path is an adapter wrapping the existing `ClaudeSDKClient`
+  logic — same code, reorganized into `backends/claude_code.py`
+- The `claude-agent-sdk` dependency remains; pydantic-ai is an optional extra
+
+---
+
+## 2. Architecture
+
+### Host/Guest Relationship
+
+**Claudechic is the host. pydantic-ai is the guest.**
+
+Claudechic owns the TUI, workflow engine, guardrails, multi-agent orchestration,
+and user experience. pydantic-ai is imported as a dependency underneath — it
+provides the LLM-calling engine and tool execution loop for non-Claude-Code
+backends. This is the same architectural position that `claude-agent-sdk`
+occupies today.
+
+Why not the reverse (claudechic as a pydantic-ai plugin):
+
+- pydantic-ai's `Agent` owns the run loop; claudechic's `Agent` class owns
+  connection lifecycle, message history, permission queue, observer pattern,
+  and TUI integration — two different "Agent" concepts that would collide
+- pydantic-ai's multi-agent model is synchronous delegation (agent-as-tool);
+  claudechic's is concurrent autonomous agents with fire-and-forget messaging
+- Claudechic's value (TUI + workflow + guardrails) would need to be rebuilt on
+  pydantic-ai primitives for no gain
+
+### Three-Layer Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    USER LAYER (claudechic)                   │
+│  TUI · Workflow Engine · Guardrails · AgentManager · Widgets│
+│  Observer pattern: on_text_chunk, on_tool_use, on_complete  │
+└────────────────────────────┬────────────────────────────────┘
+                             │ AgentBackend protocol
+                             │ (BackendEvent iterator)
+┌────────────────────────────┴────────────────────────────────┐
+│                   INTEGRATION LAYER (new)                    │
+│  AgentBackend protocol · BackendEvent types · Backend factory│
+│  Tool bridge (MCP ↔ FunctionToolset) · Guardrails adapter   │
+│  Permission bridge · Error normalization                     │
+└──────────┬──────────────────────────────────┬───────────────┘
+           │                                  │
+┌──────────┴──────────┐          ┌────────────┴───────────────┐
+│ ClaudeCodeBackend   │          │ PydanticAIBackend          │
+│                     │          │                             │
+│ claude-agent-sdk    │          │ pydantic-ai Agent.iter()   │
+│ ClaudeSDKClient     │          │ FunctionToolset (file ops) │
+│ CLI subprocess      │          │ Hooks (guardrails +        │
+│ MCP server (chic)   │          │        permissions)        │
+│                     │          │ Model abstraction (15+)    │
+│ Tools: built into   │          │                             │
+│ Claude Code CLI     │          │ Tools: implemented by      │
+│                     │          │ claudechic locally         │
+└─────────────────────┘          └─────────────────────────────┘
+```
+
+### How `Agent.iter()` Maps to the Observer Pattern
+
+Today, `agent.py:_process_response` (line 750) iterates over SDK messages:
+
+```python
+await self.client.query(prompt)
+async for msg in self.client.receive_response():
+    # dispatch msg → observer callbacks
+```
+
+With the backend protocol, it iterates over `BackendEvent` objects:
+
+```python
+async for event in self.backend.send_and_stream(prompt):
+    if isinstance(event, TextChunkEvent):       → observer.on_text_chunk()
+    elif isinstance(event, ToolUseEvent):       → observer.on_tool_use()
+    elif isinstance(event, ToolResultEvent):    → observer.on_tool_result()
+    elif isinstance(event, PermissionRequestEvent): → observer.on_prompt_added()
+    elif isinstance(event, ErrorEvent):         → observer.on_error()
+    elif isinstance(event, CompleteEvent):      → observer.on_complete()
+```
+
+Inside `PydanticAIBackend.send_and_stream()`, pydantic-ai's `Agent.iter()` runs
+node-by-node, translating each node into `BackendEvent` objects:
+
+```
+ModelRequestNode  →  stream PartDeltaEvents  →  yield TextChunkEvent
+                     stream PartStartEvents  →  accumulate tool args
+                     PartStartEvent complete →  yield ToolUseEvent (with full input)
+CallToolsNode     →  before_tool_execute     →  yield PermissionRequestEvent (if needed)
+                     after execution         →  yield ToolResultEvent
+End               →                          →  yield CompleteEvent
+```
+
+The existing observer callbacks (`AgentObserver` protocol in `protocols.py`) are
+**completely unchanged**. `ChatView` receives the same events regardless of
+backend.
+
+---
+
+## 3. New Files & Modifications
+
+### New Files
+
+| File | Purpose | Est. LOC |
+|------|---------|----------|
+| `claudechic/backends/__init__.py` | Exports protocol, factory, event types | ~30 |
+| `claudechic/backends/protocol.py` | `AgentBackend` Protocol + `BackendEvent` dataclasses | ~120 |
+| `claudechic/backends/claude_code.py` | Wraps `ClaudeSDKClient` — extracted from `agent.py` | ~200 |
+| `claudechic/backends/pydantic_ai_backend.py` | Wraps `pydantic_ai.Agent.iter()` | ~350 |
+| `claudechic/backends/tools/__init__.py` | Tool registry exports | ~10 |
+| `claudechic/backends/tools/filesystem.py` | Read, Write, Edit, Glob, Grep implementations | ~300 |
+| `claudechic/backends/tools/shell.py` | Bash, Ls implementations | ~100 |
+| `claudechic/backends/tools/chic_toolset.py` | Orchestration tools as `FunctionToolset` | ~150 |
+| `claudechic/backends/tools/mcp_impl.py` | Shared implementation functions for MCP/toolset | ~200 |
+| `tests/test_backends.py` | Unit tests: protocol, tools, integration | ~250 |
+| `tests/test_backend_security.py` | Security tests: path traversal, bash injection, OOM | ~150 |
+| `tests/test_backend_characterization.py` | Characterization tests for ClaudeCodeBackend | ~100 |
+| **Total new code** | | **~1960** |
+
+### Modified Files
+
+| File | Changes | Est. Lines Changed |
+|------|---------|-------------------|
+| `agent.py` | Replace `ClaudeSDKClient` with `AgentBackend`; refactor `connect()`, `disconnect()`, `_process_response()`, `interrupt()`; move drain logic to backend | ~150 |
+| `agent_manager.py` | Replace `ClaudeAgentOptions` with backend factory; update `create()`, `connect_agent()` | ~40 |
+| `app.py` | Add `--backend` handling; `_make_options()` becomes `_make_backend()`; add config loading | ~60 |
+| `mcp.py` | Extract tool impl functions into `mcp_impl.py`; keep MCP `@tool` wrappers calling shared impls | ~60 |
+| `guardrails/hooks.py` | Add pydantic-ai hook adapter alongside existing `HookMatcher` path | ~30 |
+| `protocols.py` | Replace `ResultMessage`/`SystemMessage` TYPE_CHECKING imports with canonical types | ~15 |
+| `messages.py` | Replace SDK type imports with canonical `ToolUseData`/`ToolResultData` types; update all Message classes | ~30 |
+| `widgets/content/tools.py` | Replace runtime `ToolUseBlock`/`ToolResultBlock` imports with canonical types | ~20 |
+| `widgets/base/tool_protocol.py` | Replace `ToolResultBlock` in protocol signature | ~5 |
+| `widgets/layout/chat_view.py` | Replace `ToolUseBlock` construction (L293, L351) with canonical types | ~15 |
+| `workflows/agent_folders.py` | Note: imports `HookMatcher` — coupling level LIGHT not NONE | ~0 |
+| `enums.py` | No change (tool names are strings, backend-agnostic) | 0 |
+| `pyproject.toml` | Add `[project.optional-dependencies]` for pydantic-ai | ~5 |
+| `tests/test_agent_permission.py` | Update SDK imports to canonical types | ~10 |
+| `tests/test_app_ui.py` | Update SDK imports to canonical types | ~10 |
+| `tests/test_widgets.py` | Update SDK imports to canonical types | ~10 |
+| **Total modified** | | **~460** |
+
+### Specific Function-Level Changes
+
+**`agent.py`:**
+
+| Function | Line | Change |
+|----------|------|--------|
+| Top-level imports | 20-39 | Remove `from claude_agent_sdk import ...`; add `from claudechic.backends.protocol import AgentBackend, ...` |
+| `Agent.__init__` | 194 | `self.client: ClaudeSDKClient` → `self.backend: AgentBackend` |
+| `Agent.connect()` | 287-319 | Accept `AgentBackend` instead of `ClaudeAgentOptions`; remove PID capture |
+| `Agent.disconnect()` | 321-338 | `self.client.disconnect()` → `self.backend.disconnect()` |
+| `Agent.interrupt()` | 536-601 | `self.client.interrupt()` → `self.backend.interrupt()`; remove `_sigint_fallback()` |
+| `Agent._is_transport_alive()` | 650-665 | → `self.backend.is_alive()` |
+| `Agent._process_response()` | 750-855 | Replace SDK message iteration with `BackendEvent` iteration; add `ErrorEvent` + `PermissionRequestEvent` handling |
+| `Agent._handle_sdk_message()` | 939-1001 | Remove (logic moves into backend adapters) |
+| `Agent._receive_with_watchdog()` | 895-937 | Remove (liveness check moves into backend) |
+| `Agent._drain_stale_on_next_response` | 772-787 | Move into `ClaudeCodeBackend` (SDK-specific behavior) |
+
+**`agent_manager.py`:**
+
+| Function | Line | Change |
+|----------|------|--------|
+| `__init__` | 32-34 | `options_factory: Callable[..., ClaudeAgentOptions]` → `backend_factory: Callable[..., AgentBackend]` |
+| `create()` | 120-171 | `self._options_factory(...)` → `self._backend_factory(...)` |
+| `connect_agent()` | 173-193 | Same pattern — use factory |
+
+**`app.py`:**
+
+| Function | Line | Change |
+|----------|------|--------|
+| `_make_options()` | 719-768 | Rename to `_make_backend()`; branch on `self.backend_type` |
+| `on_mount()` | 770+ | Pass `_make_backend` as factory to `AgentManager` |
+| CLI arg parsing | `__main__.py` | Add `--backend` flag |
+
+**`messages.py`:**
+
+| Class | Change |
+|-------|--------|
+| `ResponseComplete` | `result: ResultMessage` → `result: CompleteEvent` |
+| `ToolUseMessage` | `block: ToolUseBlock` → `block: ToolUseData` (new canonical dataclass) |
+| `ToolResultMessage` | `block: ToolResultBlock` → `block: ToolResultData` (new canonical dataclass) |
+| `SDKSystemMessage` (import) | → `SystemEvent` from protocol |
+
+**Widget files:**
+
+| File | Change |
+|------|--------|
+| `widgets/content/tools.py` | Replace `ToolUseBlock` / `ToolResultBlock` with `ToolUseData` / `ToolResultData` |
+| `widgets/base/tool_protocol.py` | Replace `ToolResultBlock` in `ToolWidget.update_result()` signature |
+| `widgets/layout/chat_view.py` | Replace `ToolUseBlock(...)` construction at L293, L351 with `ToolUseData(...)` |
+
+---
+
+## 4. AgentBackend Protocol
+
+### Protocol Definition
+
+```python
+# claudechic/backends/protocol.py
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, AsyncIterator, Protocol
+
+
+# ---------------------------------------------------------------------------
+# BackendEvent types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TextChunkEvent:
+    """Streaming text from the LLM."""
+    text: str
+    new_message: bool = False
+    parent_tool_use_id: str | None = None
+
+
+@dataclass
+class ToolUseEvent:
+    """LLM is requesting a tool call."""
+    id: str
+    name: str
+    input: dict[str, Any]
+    parent_tool_use_id: str | None = None
+
+
+@dataclass
+class ToolResultEvent:
+    """Result from a tool execution."""
+    tool_use_id: str
+    output: str
+    is_error: bool = False
+
+
+@dataclass
+class PermissionRequestEvent:
+    """Backend is requesting user approval for a tool call.
+
+    Emitted by pydantic-ai backend when a tool call needs interactive
+    approval. The backend pauses execution and waits for approval/denial
+    via the approval_event before continuing.
+
+    For Claude Code backend, permissions are handled internally by the
+    SDK's can_use_tool callback and this event is never emitted.
+    """
+    tool_use_id: str
+    tool_name: str
+    tool_input: dict[str, Any]
+    approval_event: asyncio.Event  # Set by UI when user responds
+    approved: bool = False         # Set by UI before setting approval_event
+
+
+@dataclass
+class ErrorEvent:
+    """Backend error that may be recoverable.
+
+    Emitted for API errors, rate limits, network issues, etc.
+    The agent layer decides whether to retry, notify user, or abort.
+    """
+    code: str                      # Machine-readable: "auth", "rate_limit", "timeout",
+                                   # "network", "empty_response", "context_overflow",
+                                   # "unsupported_model", "tool_error", "unknown"
+    message: str                   # Human-readable description
+    recoverable: bool = True       # Whether retry might succeed
+    retry_after_ms: int | None = None  # Suggested retry delay (e.g., 429 Retry-After)
+
+
+@dataclass
+class CompleteEvent:
+    """LLM response is complete."""
+    session_id: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    duration_ms: int | None = None
+    cost_usd: float | None = None
+    model: str | None = None
+
+
+@dataclass
+class SystemEvent:
+    """Backend system message (informational)."""
+    subtype: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+BackendEvent = (
+    TextChunkEvent | ToolUseEvent | ToolResultEvent | PermissionRequestEvent
+    | ErrorEvent | CompleteEvent | SystemEvent
+)
+
+
+# ---------------------------------------------------------------------------
+# Canonical tool data types (replacing SDK ToolUseBlock/ToolResultBlock)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ToolUseData:
+    """Backend-agnostic tool use representation.
+
+    Replaces claude_agent_sdk.ToolUseBlock in all widget and message code.
+    Both ClaudeCodeBackend and PydanticAIBackend produce these.
+    """
+    id: str
+    name: str
+    input: dict[str, Any]
+
+
+@dataclass
+class ToolResultData:
+    """Backend-agnostic tool result representation.
+
+    Replaces claude_agent_sdk.ToolResultBlock in all widget and message code.
+    """
+    tool_use_id: str
+    output: str
+    is_error: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Backend configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BackendConfig:
+    """Common configuration for all backends."""
+    cwd: Path
+    model: str | None = None
+    agent_name: str | None = None
+    agent_type: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+    resume_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# AgentBackend protocol
+# ---------------------------------------------------------------------------
+
+class AgentBackend(Protocol):
+    """Protocol for LLM backend adapters.
+
+    Each claudechic Agent owns one AgentBackend instance. The backend
+    handles LLM communication, tool execution (if applicable), and
+    streaming events back to the agent via an async iterator.
+    """
+
+    async def connect(self) -> None:
+        """Establish connection to the backend.
+
+        For Claude Code: spawns CLI subprocess via ClaudeSDKClient.
+        For pydantic-ai: validates model is reachable (quick ping).
+        """
+        ...
+
+    async def disconnect(self) -> None:
+        """Gracefully shut down the backend connection."""
+        ...
+
+    async def send_and_stream(
+        self,
+        prompt: str,
+        *,
+        images: list[bytes] | None = None,
+    ) -> AsyncIterator[BackendEvent]:
+        """Send a prompt and stream events back.
+
+        This is the core agentic loop. For Claude Code, this wraps
+        client.query() + client.receive_response(). For pydantic-ai,
+        this wraps Agent.iter() with node-by-node streaming.
+
+        The iterator yields events until the LLM response is complete.
+        The final event should be a CompleteEvent.
+
+        Args:
+            prompt: The user message text.
+            images: Optional list of image bytes (PNG/JPEG). Supported by
+                    ClaudeCodeBackend (existing functionality). PydanticAIBackend
+                    ignores this in Phase 1 (raises NotImplementedError if provided).
+        """
+        ...
+
+    async def interrupt(self) -> None:
+        """Interrupt the current response.
+
+        For Claude Code: calls client.interrupt() + SIGINT fallback.
+        For pydantic-ai: cancels the iter() async context.
+        """
+        ...
+
+    def is_alive(self) -> bool:
+        """Check whether the backend is still connected.
+
+        For Claude Code: checks CLI subprocess PID.
+        For pydantic-ai: always True (stateless HTTP).
+        """
+        ...
+
+    @property
+    def session_id(self) -> str | None:
+        """Current session ID, if the backend supports session persistence."""
+        ...
+
+    @property
+    def supports_resume(self) -> bool:
+        """Whether the backend supports session resume."""
+        ...
+
+    @property
+    def supports_permission_modes(self) -> bool:
+        """Whether the backend supports permission mode cycling."""
+        ...
+```
+
+### Error Handling Behavior
+
+The `ErrorEvent` enables consistent error handling across backends:
+
+| Error Scenario | `code` | `recoverable` | Agent Behavior |
+|---|---|---|---|
+| Bad API key / auth failure | `"auth"` | `False` | Show error, prompt user to fix config |
+| Rate limit (429) | `"rate_limit"` | `True` | Auto-retry after `retry_after_ms`; show toast |
+| Network timeout | `"timeout"` | `True` | Retry once; if repeated, notify user |
+| Empty LLM response | `"empty_response"` | `True` | Retry with "Please provide a response" |
+| Model doesn't support function calling | `"unsupported_model"` | `False` | Show error: "Model X doesn't support tool use. Choose a different model." |
+| Context window exceeded | `"context_overflow"` | `False` | Show error: "Context window full. Start a new agent or use /compact (Claude Code only)." |
+| Model not found | `"unsupported_model"` | `False` | Show error with list of available models |
+
+For `ClaudeCodeBackend`, SDK exceptions are caught and translated to `ErrorEvent`:
+- `CLIConnectionError` → `ErrorEvent(code="network", ...)`
+- `CLIJSONDecodeError` → `ErrorEvent(code="tool_error", ..., recoverable=True)`
+
+### ClaudeCodeBackend Implementation
+
+Wraps the existing `ClaudeSDKClient` logic extracted from `agent.py`:
+
+**WARNING:** This extraction accesses private SDK attributes
+(`client._query.transport._process.pid` in `_is_transport_alive`, and
+`client._transport.write()` for image messages). These are fragile coupling
+points. Write characterization tests BEFORE refactoring to catch any breakage.
+
+```python
+# claudechic/backends/claude_code.py
+
+class ClaudeCodeBackend:
+    """Backend adapter for Claude Code CLI via claude-agent-sdk."""
+
+    def __init__(self, options: ClaudeAgentOptions):
+        self._options = options
+        self._client: ClaudeSDKClient | None = None
+        self._claude_pid: int | None = None
+        self._session_id: str | None = None
+        self._drain_stale_on_next: bool = False  # SDK-specific stale message drain
+
+    async def connect(self) -> None:
+        self._client = ClaudeSDKClient(self._options)
+        await self._client.connect()
+        self._claude_pid = get_claude_pid_from_client(self._client)
+
+    async def disconnect(self) -> None:
+        if self._client:
+            await self._client.disconnect()
+            self._client = None
+        self._claude_pid = None
+
+    async def send_and_stream(
+        self,
+        prompt: str,
+        *,
+        images: list[bytes] | None = None,
+    ) -> AsyncIterator[BackendEvent]:
+        # Handle image attachments (existing agent.py:757-764 logic)
+        if images:
+            message = self._build_message_with_images(prompt, images)
+            await self._client._transport.write(json.dumps(message) + "\n")
+        else:
+            await self._client.query(prompt)
+
+        # Drain stale messages from previous interrupted response
+        # (SDK-specific behavior — see agent.py:772-787)
+        if self._drain_stale_on_next:
+            self._drain_stale_on_next = False
+            async for msg in self._client.receive_response():
+                if isinstance(msg, (AssistantMessage, StreamEvent)):
+                    yield from self._translate_message(msg)
+                    break
+                # Stale message from interrupted response — skip
+            else:
+                pass  # Iterator exhausted, fresh response next
+
+        async for msg in self._client.receive_response():
+            # Translate SDK messages → BackendEvent
+            if isinstance(msg, AssistantMessage):
+                for block in msg.content:
+                    if isinstance(block, ToolUseBlock):
+                        yield ToolUseEvent(id=block.id, name=block.name,
+                                           input=block.input)
+                    elif isinstance(block, ToolResultBlock):
+                        yield ToolResultEvent(tool_use_id=block.tool_use_id,
+                                              output=block.output or "",
+                                              is_error=block.is_error)
+            elif isinstance(msg, StreamEvent):
+                # Extract text deltas
+                yield TextChunkEvent(text=delta_text)
+            elif isinstance(msg, ResultMessage):
+                self._session_id = msg.session_id
+                yield CompleteEvent(session_id=msg.session_id,
+                                    input_tokens=msg.input_tokens,
+                                    output_tokens=msg.output_tokens,
+                                    model=msg.model)
+
+    async def interrupt(self) -> None:
+        # Existing interrupt + SIGINT fallback logic from agent.py:536-641
+        if self._client:
+            try:
+                await asyncio.wait_for(self._client.interrupt(), timeout=5.0)
+            except asyncio.TimeoutError:
+                self._sigint_fallback()
+            except Exception:
+                pass
+        self._drain_stale_on_next = True
+
+    def _sigint_fallback(self) -> None:
+        """Send SIGINT directly to CLI subprocess (last-resort interrupt).
+
+        WARNING: Accesses private SDK attributes. See R8 risk entry.
+        """
+        import signal, os
+        try:
+            client = self._client
+            if not client:
+                return
+            query = getattr(client, "_query", None)
+            transport = getattr(query, "transport", None) if query else None
+            process = getattr(transport, "_process", None) if transport else None
+            if process and process.pid and process.returncode is None:
+                os.kill(process.pid, signal.SIGINT)
+        except (ProcessLookupError, OSError):
+            pass
+
+    def is_alive(self) -> bool:
+        # Existing _is_transport_alive logic from agent.py:650-665
+        # WARNING: Accesses private SDK attributes. See R8 risk entry.
+        try:
+            client = self._client
+            if not client:
+                return False
+            query = getattr(client, "_query", None)
+            transport = getattr(query, "transport", None) if query else None
+            process = getattr(transport, "_process", None) if transport else None
+            return bool(process and process.pid and process.returncode is None)
+        except Exception:
+            return False
+
+    @property
+    def supports_resume(self) -> bool:
+        return True
+
+    @property
+    def supports_permission_modes(self) -> bool:
+        return True
+```
+
+### PydanticAIBackend Implementation
+
+```python
+# claudechic/backends/pydantic_ai_backend.py
+
+import json
+from pydantic_ai import Agent as PaiAgent
+from pydantic_ai.hooks import Hooks, SkipToolExecution
+from pydantic_ai.agent import PartDeltaEvent, PartStartEvent
+
+class PydanticAIBackend:
+    """Backend adapter using pydantic-ai Agent.iter()."""
+
+    def __init__(
+        self,
+        model: str,                           # e.g. "openai:gpt-4o"
+        cwd: Path,
+        toolsets: list,                        # FunctionToolsets
+        hooks: Hooks,                          # guardrails + permissions
+        agent_name: str | None = None,
+        system_prompt: str | None = None,      # includes available tools list
+    ):
+        self._model = model
+        self._cwd = cwd
+        self._messages: list = []              # conversation history
+        self._cancel_event = asyncio.Event()
+        self._current_run = None
+        self._tool_result_queue: asyncio.Queue[ToolResultEvent] = asyncio.Queue()
+
+        self._pai_agent = PaiAgent(
+            model,
+            toolsets=toolsets,
+            hooks=hooks,
+            system_prompt=system_prompt or self._default_system_prompt(),
+        )
+
+    def _default_system_prompt(self) -> str:
+        """System prompt explicitly listing available/unavailable tools."""
+        return (
+            "You have access to these tools: Read, Write, Edit, Glob, Grep, "
+            "Bash, Ls, spawn_agent, tell_agent, ask_agent, close_agent, "
+            "list_agents, advance_phase, get_phase, acknowledge_warning, "
+            "request_override, whoami.\n\n"
+            "The following tools are NOT available in this backend and you "
+            "must NOT attempt to call them: WebSearch, WebFetch, "
+            "NotebookEdit, TodoWrite, AskUserQuestion. "
+            "Use Bash + curl for web requests. "
+            "Edit notebooks manually or via Bash."
+        )
+
+    async def connect(self) -> None:
+        # Validate model is reachable (optional quick check)
+        pass
+
+    async def disconnect(self) -> None:
+        self._messages.clear()
+
+    async def send_and_stream(
+        self,
+        prompt: str,
+        *,
+        images: list[bytes] | None = None,
+    ) -> AsyncIterator[BackendEvent]:
+        if images:
+            # Phase 1: image support not implemented for pydantic-ai
+            yield ErrorEvent(
+                code="unsupported_feature",
+                message="Image input not supported on pydantic-ai backend (Phase 1). "
+                        "Use Claude Code backend for image tasks.",
+                recoverable=False,
+            )
+            return
+
+        self._cancel_event.clear()
+
+        try:
+            async with self._pai_agent.iter(
+                prompt,
+                message_history=self._messages,
+            ) as agent_run:
+                self._current_run = agent_run
+
+                async for node in agent_run:
+                    if self._cancel_event.is_set():
+                        break
+
+                    # ModelRequestNode: LLM is generating
+                    if PaiAgent.is_model_request_node(node):
+                        async with node.stream(agent_run.ctx) as stream:
+                            # Tool argument accumulator
+                            # PartStartEvent fires when a new tool call begins.
+                            # PartDeltaEvents carry incremental args_delta JSON.
+                            # We accumulate args and emit ToolUseEvent only when
+                            # the tool call part is complete (next PartStart or
+                            # stream ends).
+                            pending_tool: dict | None = None
+                            pending_args_json: str = ""
+
+                            async for event in stream:
+                                if isinstance(event, PartStartEvent):
+                                    # Flush previous pending tool if any
+                                    if pending_tool is not None:
+                                        try:
+                                            parsed_args = json.loads(pending_args_json) if pending_args_json else {}
+                                        except json.JSONDecodeError:
+                                            parsed_args = {"_raw": pending_args_json}
+                                        yield ToolUseEvent(
+                                            id=pending_tool["id"],
+                                            name=pending_tool["name"],
+                                            input=parsed_args,
+                                        )
+                                        pending_tool = None
+                                        pending_args_json = ""
+
+                                    # New part starting
+                                    if hasattr(event.part, 'tool_name'):
+                                        # Start accumulating a new tool call
+                                        pending_tool = {
+                                            "id": event.part.tool_call_id,
+                                            "name": event.part.tool_name,
+                                        }
+                                        pending_args_json = ""
+                                    # else: text part — no accumulation needed
+
+                                elif isinstance(event, PartDeltaEvent):
+                                    if pending_tool is not None:
+                                        # Accumulate tool argument deltas
+                                        if hasattr(event.delta, 'args_delta'):
+                                            pending_args_json += event.delta.args_delta
+                                    elif hasattr(event.delta, 'content_delta'):
+                                        if event.delta.content_delta:
+                                            yield TextChunkEvent(
+                                                text=event.delta.content_delta
+                                            )
+
+                            # Flush final pending tool at end of stream
+                            if pending_tool is not None:
+                                try:
+                                    parsed_args = json.loads(pending_args_json) if pending_args_json else {}
+                                except json.JSONDecodeError:
+                                    parsed_args = {"_raw": pending_args_json}
+                                yield ToolUseEvent(
+                                    id=pending_tool["id"],
+                                    name=pending_tool["name"],
+                                    input=parsed_args,
+                                )
+
+                    # CallToolsNode: tool results available
+                    elif PaiAgent.is_call_tools_node(node):
+                        # Drain tool results from the node directly.
+                        # pydantic-ai stores results on the node after execution.
+                        # Also drain any results pushed via the hook queue
+                        # (for permission-gated tools).
+                        for part in node.data.parts:
+                            if hasattr(part, 'tool_name'):
+                                yield ToolResultEvent(
+                                    tool_use_id=part.tool_call_id,
+                                    output=str(part.content) if hasattr(part, 'content') else "",
+                                    is_error=False,
+                                )
+                        # Also drain any queued results from hooks
+                        while not self._tool_result_queue.empty():
+                            yield self._tool_result_queue.get_nowait()
+
+                # Run complete
+                if agent_run.result:
+                    self._messages = agent_run.result.all_messages()
+                    usage = agent_run.usage()
+                    yield CompleteEvent(
+                        input_tokens=usage.request_tokens,
+                        output_tokens=usage.response_tokens,
+                        model=self._model,
+                    )
+
+        except Exception as e:
+            # Translate pydantic-ai exceptions to ErrorEvents
+            error_event = self._translate_exception(e)
+            yield error_event
+            if not error_event.recoverable:
+                return
+
+    def _translate_exception(self, e: Exception) -> ErrorEvent:
+        """Map pydantic-ai / HTTP exceptions to ErrorEvent."""
+        error_str = str(e).lower()
+        error_type = type(e).__name__
+
+        if "401" in error_str or "unauthorized" in error_str or "api key" in error_str:
+            return ErrorEvent(code="auth", message=f"Authentication failed: {e}", recoverable=False)
+        elif "429" in error_str or "rate limit" in error_str:
+            return ErrorEvent(code="rate_limit", message=f"Rate limited: {e}", recoverable=True, retry_after_ms=60000)
+        elif "timeout" in error_str or "TimeoutError" in error_type:
+            return ErrorEvent(code="timeout", message=f"Request timed out: {e}", recoverable=True)
+        elif "context" in error_str and ("length" in error_str or "window" in error_str or "token" in error_str):
+            return ErrorEvent(code="context_overflow", message=f"Context window exceeded: {e}", recoverable=False)
+        elif "connection" in error_str or "network" in error_str:
+            return ErrorEvent(code="network", message=f"Network error: {e}", recoverable=True)
+        else:
+            return ErrorEvent(code="unknown", message=f"Backend error: {e}", recoverable=False)
+
+    async def interrupt(self) -> None:
+        self._cancel_event.set()
+
+    def is_alive(self) -> bool:
+        return True  # HTTP-based, no subprocess
+
+    @property
+    def session_id(self) -> str | None:
+        return None  # Phase 1: no session persistence
+
+    @property
+    def supports_resume(self) -> bool:
+        return False
+
+    @property
+    def supports_permission_modes(self) -> bool:
+        return False
+```
+
+---
+
+## 5. Tool Implementations
+
+For non-Claude-Code backends, claudechic must provide its own tool
+implementations. Claude Code's built-in tools (Read, Write, Edit, Bash, Glob,
+Grep) are provided by the CLI subprocess and are not available via pydantic-ai.
+
+### Tool List
+
+| Tool | Description | Est. LOC | Security Notes |
+|------|-------------|----------|----------------|
+| `Read` | Read file with line numbers (cat -n format) | ~40 | Path traversal check; configurable line limit (default 2000); **file size check (10MB cap)** |
+| `Write` | Write/overwrite file | ~25 | Path traversal check; parent directory must exist |
+| `Edit` | String replacement in file | ~45 | Unique match validation; `replace_all` flag support; file size check |
+| `Glob` | File pattern matching | ~25 | Rooted to cwd; sorted by mtime |
+| `Grep` | Regex content search (via ripgrep or stdlib) | ~45 | Output truncation at 30K chars; timeout for large repos |
+| `Bash` | Shell command execution | ~60 | Configurable timeout (default 120s); **output truncation at 30K chars**; subprocess resource limits |
+| `Ls` | List directory contents | ~20 | Rooted to cwd |
+| **Total** | | **~260** | |
+
+### Registration as FunctionToolset
+
+```python
+# claudechic/backends/tools/filesystem.py
+
+from pydantic_ai.toolsets import FunctionToolset
+
+# Maximum file size for Read/Edit operations (prevent OOM on large files)
+_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024  # 10MB
+
+# Maximum tool output length (prevent token explosion)
+_MAX_OUTPUT_CHARS = 30_000  # ~30K chars ≈ ~7.5K tokens
+
+def _resolve_and_check(cwd: Path, file_path: str) -> Path:
+    """Resolve path and enforce cwd jail."""
+    path = (cwd / file_path).resolve()
+    if not path.is_relative_to(cwd.resolve()):
+        raise ToolError(f"Path escapes working directory: {file_path}")
+    return path
+
+def _check_file_size(path: Path) -> None:
+    """Reject files over the size limit to prevent OOM."""
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return  # File doesn't exist yet; let the caller handle it
+    if size > _MAX_FILE_SIZE_BYTES:
+        raise ToolError(
+            f"File too large ({size / 1024 / 1024:.1f}MB > "
+            f"{_MAX_FILE_SIZE_BYTES / 1024 / 1024:.0f}MB limit). "
+            f"Use offset/limit parameters or Bash to read portions."
+        )
+
+def _truncate_output(text: str) -> str:
+    """Truncate output to prevent token explosion."""
+    if len(text) > _MAX_OUTPUT_CHARS:
+        return text[:_MAX_OUTPUT_CHARS] + f"\n\n... (truncated, {len(text)} total chars)"
+    return text
+
+def create_file_toolset(cwd: Path) -> FunctionToolset:
+    """Create toolset with file operation tools rooted at cwd."""
+    ts = FunctionToolset()
+
+    @ts.tool_plain
+    async def Read(file_path: str, offset: int = 0, limit: int = 2000) -> str:
+        """Read a file from the filesystem. Returns numbered lines."""
+        path = _resolve_and_check(cwd, file_path)
+        _check_file_size(path)
+        content = await asyncio.to_thread(
+            path.read_text, encoding="utf-8", errors="replace"
+        )
+        lines = content.splitlines()
+        selected = lines[offset:offset + limit]
+        result = "\n".join(f"{i + offset + 1}\t{line}" for i, line in enumerate(selected))
+        return _truncate_output(result)
+
+    @ts.tool_plain
+    async def Edit(file_path: str, old_string: str, new_string: str,
+                   replace_all: bool = False) -> str:
+        """Replace text in a file. old_string must be unique unless replace_all=True."""
+        path = _resolve_and_check(cwd, file_path)
+        _check_file_size(path)
+        content = await asyncio.to_thread(path.read_text)
+        count = content.count(old_string)
+        if count == 0:
+            raise ToolError(f"old_string not found in {file_path}")
+        if count > 1 and not replace_all:
+            raise ToolError(f"old_string matches {count} times (not unique)")
+        result = content.replace(old_string, new_string, -1 if replace_all else 1)
+        await asyncio.to_thread(path.write_text, result)
+        return f"Edited {file_path}"
+
+    @ts.tool_plain
+    async def Write(file_path: str, content: str) -> str:
+        """Write content to a file, overwriting if it exists."""
+        path = _resolve_and_check(cwd, file_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(path.write_text, content)
+        return f"Wrote {file_path}"
+
+    # ... Glob, Grep, Bash, Ls similarly
+
+    return ts
+```
+
+### Security Considerations
+
+- **Path traversal**: All paths resolved against `cwd`; refuse paths that
+  resolve outside cwd (e.g., `../../etc/passwd`). Use `Path.resolve()` and
+  check `path.is_relative_to(cwd)`.
+- **File size limits**: Read and Edit check file size before loading into memory.
+  Files over 10MB are rejected with instructions to use `offset`/`limit` or Bash.
+  This prevents OOM conditions on large binary files or logs.
+- **Output truncation**: Tool outputs capped at 30K characters (~7.5K tokens) to
+  avoid context window explosion. 30K is chosen to stay well under pydantic-ai's
+  default tool output limits while being large enough for most tool results.
+  Large files should use `offset`/`limit` parameters.
+- **Bash timeouts**: Default 120 seconds, configurable. Subprocess killed on
+  timeout. Use `asyncio.create_subprocess_shell` with `communicate(timeout=)`.
+  Bash output also truncated at 30K chars.
+- **Bash security**: Guardrails rules apply before tool execution (see Section 7).
+  Dangerous commands (rm -rf, git push --force, etc.) are caught by the same
+  rules that protect Claude Code usage today. Semantic command filtering via
+  guardrails is the **primary gate**; tool-level restrictions are defense-in-depth
+  only.
+- **Encoding**: All file reads use `utf-8` with `errors="replace"` to handle
+  binary files gracefully.
+- **NFS considerations**: This project runs on HPC cluster with NFS-mounted
+  filesystems. File I/O is wrapped in `asyncio.to_thread()` to avoid blocking
+  the event loop on NFS latency spikes. Avoid `os.stat()` in hot paths; prefer
+  catching `OSError` over pre-checking existence. No mtime caching (NFS may
+  have stale attribute caches).
+
+---
+
+## 6. Orchestration Tool Bridge
+
+### Problem
+
+Claudechic's MCP tools (`spawn_agent`, `tell_agent`, `ask_agent`, `close_agent`,
+`list_agents`, `advance_phase`, `get_phase`, `acknowledge_warning`,
+`request_override`, `whoami`) are currently registered using
+`claude_agent_sdk`'s `@tool` decorator and served via
+`create_sdk_mcp_server()` (see `mcp.py:23`, `mcp.py:160-287`).
+
+For the pydantic-ai backend, these same tools need to be registered as a
+pydantic-ai `FunctionToolset` so the LLM can call them via function calling.
+
+### Solution: Dual Registration with Shared Implementations
+
+Extract the business logic from `mcp.py`'s `@tool`-decorated functions into
+standalone `async def _impl_*()` functions. Both the MCP path and the
+FunctionToolset path call the same implementation.
+
+```
+mcp.py (Claude Code path)          chic_toolset.py (pydantic-ai path)
+┌─────────────────────────┐        ┌──────────────────────────────────┐
+│ @tool("spawn_agent")    │        │ @ts.tool_plain                   │
+│ async def spawn_agent() │        │ async def spawn_agent()          │
+│     return _impl_spawn()│        │     return _impl_spawn()         │
+└────────────┬────────────┘        └────────────────┬─────────────────┘
+             │                                      │
+             └──────────────┬───────────────────────┘
+                            │
+                  ┌─────────┴─────────┐
+                  │ _impl_spawn()     │
+                  │ (shared logic in  │
+                  │  mcp_impl.py)     │
+                  └───────────────────┘
+```
+
+### App Reference: Dependency Injection
+
+The shared implementation functions need access to the `ChatApp` instance
+(specifically `app.agent_mgr` and `app._workflow_engine`). Instead of
+relying on the `_app` global from `mcp.py`, the shared module uses an
+explicit registration pattern:
+
+```python
+# claudechic/backends/tools/mcp_impl.py
+
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from claudechic.app import ChatApp
+
+_app: ChatApp | None = None
+
+def register_app(app: ChatApp) -> None:
+    """Register the app instance for shared tool implementations.
+
+    Called once from ChatApp.on_mount(). Both mcp.py and chic_toolset.py
+    call into this module's _impl_* functions, which use _app to access
+    the AgentManager and WorkflowEngine.
+
+    This is the same pattern as mcp.py's set_app() — we consolidate
+    both into a single registration point.
+    """
+    global _app
+    _app = app
+
+def _require_app():
+    """Get app reference or raise clear error."""
+    if _app is None or _app.agent_mgr is None:
+        raise RuntimeError("App not initialized — register_app() not called")
+    return _app
+```
+
+### Shared Implementation Module
+
+```python
+# claudechic/backends/tools/mcp_impl.py (continued)
+
+async def _impl_spawn_agent(
+    name: str, path: str, prompt: str,
+    model: str = "", agent_type: str = "",
+    caller_name: str | None = None,
+    requires_answer: bool = False,
+) -> str:
+    """Shared spawn_agent logic (extracted from mcp.py:179-287)."""
+    app = _require_app()
+    # Exactly the current mcp.py logic:
+    # - validate path exists
+    # - check agent name uniqueness
+    # - call app.agent_mgr.create()
+    # - inject workflow agent folder prompt
+    # - fire-and-forget initial prompt
+    ...
+
+async def _impl_tell_agent(name: str, message: str, caller_name: str | None) -> str:
+    """Shared tell_agent logic (extracted from mcp.py)."""
+    app = _require_app()
+    ...
+
+# etc. for ask_agent, close_agent, list_agents, advance_phase, get_phase,
+# acknowledge_warning, request_override, whoami
+```
+
+### pydantic-ai FunctionToolset Registration
+
+```python
+def create_chic_toolset(caller_name: str | None = None) -> FunctionToolset:
+    ts = FunctionToolset()
+
+    @ts.tool_plain
+    async def spawn_agent(name: str, path: str, prompt: str,
+                          model: str = "", type: str = "",
+                          requires_answer: bool = False) -> str:
+        """Create a new agent in claudechic."""
+        return await _impl_spawn_agent(
+            name, path, prompt, model, type,
+            caller_name=caller_name,
+            requires_answer=requires_answer,
+        )
+
+    @ts.tool_plain
+    async def tell_agent(name: str, message: str) -> str:
+        """Send a message to another agent (no reply expected)."""
+        return await _impl_tell_agent(name, message, caller_name)
+
+    @ts.tool_plain
+    async def ask_agent(name: str, prompt: str) -> str:
+        """Ask another agent a question (expects reply)."""
+        return await _impl_ask_agent(name, prompt, caller_name)
+
+    @ts.tool_plain
+    async def advance_phase() -> str:
+        """Advance the workflow to its next phase."""
+        return await _impl_advance_phase()
+
+    @ts.tool_plain
+    async def get_phase() -> str:
+        """Get current workflow phase and loaded rules."""
+        return await _impl_get_phase()
+
+    # ... close_agent, list_agents, acknowledge_warning, request_override, whoami
+
+    return ts
+```
+
+---
+
+## 7. Guardrails Integration
+
+### Current Architecture
+
+Claudechic's guardrails evaluate rules via `PreToolUse` hooks
+(`guardrails/hooks.py:36-58`). The `create_guardrail_hooks()` function returns
+a `dict[str, list[HookMatcher]]` that the Claude Code SDK evaluates before each
+tool call. The two-step pipeline:
+
+1. **Injections** — mutate `tool_input` in-place (e.g., append system prompts)
+2. **Enforcement** — evaluate rules: `deny` → block, `warn` → require ack,
+   `log` → audit only
+
+### pydantic-ai Mapping
+
+pydantic-ai's hook system provides `before_tool_execute` and
+`after_tool_execute` hooks that fire for every tool call. The mapping is direct:
+
+| Claudechic Guardrail | pydantic-ai Hook | Mechanism |
+|---------------------|------------------|-----------|
+| `deny` enforcement | `before_tool_execute` | Raise `SkipToolExecution("Blocked: ...")` |
+| `warn` enforcement | `before_tool_execute` | Raise `SkipToolExecution` with ack instructions |
+| `log` enforcement | `after_tool_execute` | Log hit, allow execution |
+| Injections | `before_tool_execute` | Mutate `args` dict, return modified args |
+| Override tokens | `before_tool_execute` | Check `consume_override` callback |
+
+### Implementation
+
+```python
+# In pydantic_ai_backend.py
+
+def _create_guardrail_hooks(
+    loader: ManifestLoader,
+    hit_logger: HitLogger,
+    agent_role: str | None,
+    get_phase: Callable[[], str | None],
+    get_active_wf: Callable[[], str | None],
+    consume_override: Callable,
+    permission_callback: Callable | None = None,  # NEW: interactive permissions
+    tool_result_queue: asyncio.Queue | None = None,  # NEW: result event queue
+) -> Hooks:
+    """Create pydantic-ai Hooks that evaluate claudechic guardrails."""
+    hooks = Hooks()
+
+    @hooks.on.before_tool_execute
+    async def evaluate_guardrails(ctx, *, call, tool_def, args):
+        tool_name = call.tool_name
+        tool_input = dict(args)  # copy for mutation safety
+
+        result = loader.load()
+
+        # Fail-closed
+        if result.errors and not result.rules:
+            fatal = any(e.source == "discovery" for e in result.errors)
+            if fatal:
+                raise SkipToolExecution(
+                    "Rules unavailable — global/ or workflows/ unreadable"
+                )
+
+        current_phase = get_phase()
+        active_wf = get_active_wf()
+
+        # Step 1: Injections
+        for injection in result.injections:
+            if injection.namespace not in ("global", active_wf):
+                continue
+            if not matches_trigger(injection, tool_name):
+                continue
+            if should_skip_for_role(injection, agent_role):
+                continue
+            if should_skip_for_phase(injection, current_phase):
+                continue
+            apply_injection(injection, tool_input)
+
+        # Step 2: Enforcement rules
+        for rule in result.rules:
+            if rule.namespace not in ("global", active_wf):
+                continue
+            if not matches_trigger(rule, tool_name):
+                continue
+            if should_skip_for_role(rule, agent_role):
+                continue
+            if should_skip_for_phase(rule, current_phase):
+                continue
+            if rule.exclude_pattern:
+                field_value = _get_field(tool_input, rule.detect_field)
+                if rule.exclude_pattern.search(field_value):
+                    continue
+            if rule.detect_pattern:
+                field_value = _get_field(tool_input, rule.detect_field)
+                if not rule.detect_pattern.search(field_value):
+                    continue
+
+            # Rule matches
+            hit = HitRecord(
+                rule_id=rule.id, agent_role=agent_role,
+                tool_name=tool_name, enforcement=rule.enforcement,
+                timestamp=time.time(),
+            )
+
+            if rule.enforcement == "log":
+                hit_logger.record(replace(hit, outcome="allowed"))
+                continue
+            elif rule.enforcement == "warn":
+                if consume_override(rule.id, tool_name, tool_input, "warn"):
+                    hit_logger.record(replace(hit, outcome="ack"))
+                    continue
+                hit_logger.record(replace(hit, outcome="blocked"))
+                raise SkipToolExecution(
+                    f"{rule.message}\n"
+                    f'acknowledge_warning(rule_id="{rule.id}", ...)'
+                )
+            elif rule.enforcement == "deny":
+                if consume_override(rule.id, tool_name, tool_input, "deny"):
+                    hit_logger.record(replace(hit, outcome="overridden"))
+                    continue
+                hit_logger.record(replace(hit, outcome="blocked"))
+                raise SkipToolExecution(
+                    f"{rule.message}\n"
+                    f'request_override(rule_id="{rule.id}", ...)'
+                )
+
+        # Step 3: Interactive permission check (NEW)
+        if permission_callback:
+            approved = await permission_callback(tool_name, tool_input)
+            if not approved:
+                raise SkipToolExecution(
+                    f"Tool '{tool_name}' denied by user."
+                )
+
+        # Return potentially-mutated args (injection support)
+        return tool_input
+
+    @hooks.on.after_tool_execute
+    async def emit_tool_result(ctx, *, call, tool_def, args, result):
+        """Push ToolResultEvent into the queue for send_and_stream to yield."""
+        if tool_result_queue is not None:
+            tool_result_queue.put_nowait(ToolResultEvent(
+                tool_use_id=call.tool_call_id,
+                output=str(result),
+                is_error=False,
+            ))
+
+    return hooks
+```
+
+### Key Design Decision
+
+The guardrails rule evaluation functions (`matches_trigger`, `should_skip_for_role`,
+`should_skip_for_phase`, `apply_injection`, `_get_field`) in
+`guardrails/rules.py` are **pure functions with no SDK imports**. They work
+identically in both the Claude Code hook path and the pydantic-ai hook path.
+Only the hook *wrapper* differs — `HookMatcher` closure (Claude Code) vs
+`Hooks.on.before_tool_execute` decorator (pydantic-ai).
+
+### 7b. Interactive Tool Permissions (pydantic-ai backend)
+
+#### Problem
+
+Claude Code's SDK has a built-in `can_use_tool` callback that pauses execution
+and asks the user for permission before running tools. The pydantic-ai backend
+has no equivalent — tools execute immediately unless blocked. Without interactive
+permissions, the pydantic-ai backend would auto-approve ALL tool calls, which
+conflicts with claudechic's safety model.
+
+#### Solution: Permission Bridge via `before_tool_execute` Hook
+
+The permission system is implemented as part of the `before_tool_execute` hook
+chain. After guardrails evaluation passes, the hook checks whether the tool
+requires interactive approval and, if so, pauses via an `asyncio.Event` until
+the TUI responds.
+
+```python
+# In pydantic_ai_backend.py
+
+class PermissionBridge:
+    """Bridges pydantic-ai tool execution to claudechic's TUI permission flow.
+
+    When a tool call requires approval:
+    1. Hook fires → creates PermissionRequestEvent with an asyncio.Event
+    2. Event is pushed into the backend's event queue
+    3. send_and_stream() yields the PermissionRequestEvent
+    4. Agent._process_response() receives it → calls observer.on_prompt_added()
+    5. TUI shows SelectionPrompt → user approves/denies
+    6. TUI sets event.approved and signals the asyncio.Event
+    7. Hook resumes → continues or raises SkipToolExecution
+    """
+
+    def __init__(
+        self,
+        event_queue: asyncio.Queue,
+        session_allowed_tools: set[str],
+    ):
+        self._event_queue = event_queue
+        self._session_allowed_tools = session_allowed_tools
+
+    async def check_permission(
+        self, tool_name: str, tool_input: dict
+    ) -> bool:
+        """Check if tool needs permission and wait for user response.
+
+        Returns True if approved, False if denied.
+        """
+        # Tools already approved for this session (user chose "allow all")
+        if tool_name in self._session_allowed_tools:
+            return True
+
+        # Read-only tools can be auto-approved in Phase 1
+        # (matches Claude Code's "default" permission mode behavior)
+        if tool_name in {"Read", "Glob", "Grep", "Ls", "list_agents",
+                         "get_phase", "whoami"}:
+            return True
+
+        # Create approval event and push to stream
+        approval_event = asyncio.Event()
+        request = PermissionRequestEvent(
+            tool_use_id=f"perm-{tool_name}-{id(approval_event)}",
+            tool_name=tool_name,
+            tool_input=tool_input,
+            approval_event=approval_event,
+        )
+        self._event_queue.put_nowait(request)
+
+        # Wait for TUI to respond
+        await approval_event.wait()
+
+        # If user chose "allow all for session", remember it
+        if request.approved and getattr(request, 'allow_session', False):
+            self._session_allowed_tools.add(tool_name)
+
+        return request.approved
+```
+
+#### Integration with `_process_response()`
+
+The Agent's response loop handles `PermissionRequestEvent` like any other event:
+
+```python
+# In agent.py _process_response():
+async for event in self.backend.send_and_stream(prompt):
+    if isinstance(event, PermissionRequestEvent):
+        # Route to TUI permission prompt
+        perm_request = PermissionRequest(
+            tool_name=event.tool_name,
+            tool_input=event.tool_input,
+        )
+        # Observer shows SelectionPrompt in TUI
+        if self.observer:
+            self.observer.on_prompt_added(self, perm_request)
+        # The PermissionBridge is waiting on event.approval_event —
+        # TUI will set it when user responds
+```
+
+**Note:** This creates a cooperative blocking pattern: the `before_tool_execute`
+hook is `await`-ing the `approval_event` while `send_and_stream()` is yielding
+the `PermissionRequestEvent` to the caller. This works because pydantic-ai's
+tool execution hook and the `send_and_stream()` iterator share the same async
+context — the hook blocks its coroutine while the iterator's next() is free to
+yield events from the queue.
+
+**Important concurrency detail:** The `PermissionRequestEvent` is pushed via a
+shared `asyncio.Queue` between the hook (running inside pydantic-ai's tool
+execution) and the `send_and_stream()` generator. The generator must poll
+this queue between node iterations.
+
+---
+
+## 8. Multi-Agent
+
+### Architecture
+
+Each claudechic `Agent` gets its own `AgentBackend` instance. For
+`PydanticAIBackend`, this means each agent has:
+
+- Its own `pydantic_ai.Agent` instance
+- Its own `message_history` list (conversation isolation)
+- Its own toolset instances (with `caller_name` bound for MCP tool routing)
+
+```
+AgentManager
+├── Agent "Coordinator" (id=abc)
+│   └── PydanticAIBackend (model="openai:gpt-4o")
+│       ├── pydantic_ai.Agent instance
+│       ├── message_history: [...]
+│       └── toolsets: [file_tools, chic_tools(caller="Coordinator")]
+├── Agent "Implementer" (id=def)
+│   └── PydanticAIBackend (model="openai:gpt-4o")
+│       ├── pydantic_ai.Agent instance
+│       ├── message_history: [...]
+│       └── toolsets: [file_tools, chic_tools(caller="Implementer")]
+└── Agent "Reviewer" (id=ghi)
+    └── PydanticAIBackend (model="openai:gpt-4o-mini")  # cheaper model
+        ├── pydantic_ai.Agent instance
+        ├── message_history: [...]
+        └── toolsets: [file_tools, chic_tools(caller="Reviewer")]
+```
+
+### spawn_agent / tell_agent / ask_agent / close_agent
+
+**No changes to the semantics.** The routing happens at the `AgentManager` level,
+not the backend level:
+
+- `spawn_agent` → `agent_mgr.create()` → creates new `Agent` + new backend
+- `tell_agent` → `agent_mgr.find_by_name()` → `agent.send(prompt)` → backend
+- `ask_agent` → same as `tell_agent` but with reply-tracking metadata
+- `close_agent` → `agent_mgr.close()` → `agent.disconnect()` → backend cleanup
+
+The `_send_prompt_fire_and_forget()` function in `mcp.py:116-154` calls
+`agent.send(prompt)`, which calls `backend.send_and_stream()`. This code path
+is backend-agnostic.
+
+### Mixed Backends (Future)
+
+The backend factory could return different backends per agent. For example,
+Coordinator on Claude Code, sub-agents on pydantic-ai with a cheaper model.
+This is architecturally possible but out of scope for Phase 1 (config
+complexity).
+
+---
+
+## 9. Configuration
+
+### New Config Options in `.claudechic.yaml`
+
+```yaml
+# Backend selection (default: claude-code)
+backend: pydantic-ai
+
+# pydantic-ai backend settings
+pydantic_ai:
+  model: openai:gpt-4o           # pydantic-ai model string
+  # model: ollama/qwen3:32b      # local Ollama
+  # model: anthropic:claude-sonnet-4-5  # Anthropic direct API
+  # model: google-gla:gemini-2.5-pro   # Google Gemini
+  api_key: ${OPENAI_API_KEY}     # env var expansion (optional)
+  temperature: 0.7               # model settings (optional)
+  max_tokens: 16384              # model settings (optional)
+```
+
+### CLI Flags
+
+```
+--backend <name>    Backend to use: "claude-code" (default) or "pydantic-ai"
+--model <string>    Model for pydantic-ai backend (e.g., "openai:gpt-4o")
+```
+
+CLI flags override `.claudechic.yaml` config.
+
+### Optional Dependency
+
+```toml
+# pyproject.toml
+[project.optional-dependencies]
+pydantic-ai = ["pydantic-ai>=1.80.0,<1.90.0"]
+```
+
+Installation:
+
+```bash
+pip install claudechic                  # Claude Code only (default)
+pip install claudechic[pydantic-ai]     # Adds pydantic-ai backend support
+```
+
+At runtime, if `--backend pydantic-ai` is specified but pydantic-ai is not
+installed, claudechic shows a clear error:
+
+```
+Error: pydantic-ai backend requires 'pydantic-ai' package.
+Install with: pip install claudechic[pydantic-ai]
+```
+
+### Getting Started with Alternative Backends
+
+Quick start guide for users switching to a non-Claude-Code backend:
+
+1. **Install the extra:**
+   ```bash
+   pip install claudechic[pydantic-ai]
+   ```
+
+2. **Set your API key:**
+   ```bash
+   # For OpenAI:
+   export OPENAI_API_KEY=sk-...
+
+   # For Anthropic direct API (not Claude Code):
+   export ANTHROPIC_API_KEY=sk-ant-...
+
+   # For Google Gemini:
+   export GOOGLE_API_KEY=...
+
+   # For Ollama (local, no key needed):
+   ollama serve  # ensure Ollama is running
+   ```
+
+3. **Choose a model** (use pydantic-ai model string format):
+   ```
+   openai:gpt-4o             # OpenAI GPT-4o
+   openai:gpt-4o-mini        # Cheaper OpenAI
+   anthropic:claude-sonnet-4-5  # Anthropic direct API
+   google-gla:gemini-2.5-pro # Google Gemini
+   ollama:qwen3:32b          # Local Ollama
+   ```
+
+4. **Run claudechic:**
+   ```bash
+   # One-time via CLI flags:
+   claudechic --backend pydantic-ai --model openai:gpt-4o
+
+   # Or set in config (~/.claude/.claudechic.yaml):
+   backend: pydantic-ai
+   pydantic_ai:
+     model: openai:gpt-4o
+   ```
+
+5. **Verify:** Look for the model name in the status footer (e.g., `● gpt-4o pydantic-ai` instead of `● opus default`). Workflows, guardrails, and multi-agent all work as normal.
+
+### Template-Specific Notes
+
+The template's MCP tools (`template/mcp_tools/slurm.py` and
+`template/mcp_tools/lsf.py`) import from `claude_agent_sdk` directly and
+remain **Claude Code-only**. They are not bridged to the pydantic-ai backend
+in Phase 1. When using pydantic-ai backend, SLURM/LSF job submission must be
+done via the `Bash` tool.
+
+---
+
+## 10. Terminology / Naming
+
+### The "Agent" Collision
+
+Both claudechic and pydantic-ai have an `Agent` class with different meanings:
+
+| Term | claudechic meaning | pydantic-ai meaning |
+|------|-------------------|---------------------|
+| Agent | Autonomous entity with SDK connection, message history, permissions, TUI | Stateless LLM-calling container with tools and output types |
+
+### Resolution: Wrapping Approach (Option C)
+
+Claudechic's `Agent` class remains the public, user-facing concept. The
+pydantic-ai `Agent` is an internal implementation detail, never exposed to
+users or to claudechic code outside of `backends/pydantic_ai_backend.py`.
+
+**Import conventions:**
+
+```python
+# Inside backends/pydantic_ai_backend.py ONLY:
+from pydantic_ai import Agent as PaiAgent
+
+# Everywhere else in claudechic:
+from claudechic.agent import Agent          # claudechic's Agent
+from claudechic.backends.protocol import AgentBackend  # the abstraction
+```
+
+The pydantic-ai `Agent` (aliased as `PaiAgent`) is never imported outside of
+`pydantic_ai_backend.py`.
+
+### User-Facing Vocabulary
+
+| User sees | Developer term | Notes |
+|-----------|---------------|-------|
+| "backend" | `AgentBackend` | Shown in config, CLI flags, status footer |
+| "model" | Model string | e.g. "openai:gpt-4o" — pydantic-ai format |
+| "agent" | `Agent` | Always claudechic's Agent — TUI sidebar entity |
+| "tool" | Tool name | e.g. "Read", "Bash" — same names regardless of backend |
+| "workflow" | Workflow/phases | Unchanged |
+| "guardrail" | Rule | Unchanged |
+
+### Status Footer Display
+
+When using pydantic-ai backend, the model label in the status footer shows
+the pydantic-ai model string instead of "opus"/"sonnet":
+
+```
+claude-code backend:    ● opus    default
+pydantic-ai backend:    ● gpt-4o  pydantic-ai
+```
+
+---
+
+## 11. Known Limitations (Phase 1)
+
+| Limitation | Impact | User Experience | Workaround |
+|-----------|--------|-----------------|------------|
+| **No session resume** | Cannot `/resume` a pydantic-ai session | `/resume` → toast: "Session resume not available on pydantic-ai backend. Planned for Phase 2." | Conversation history lost on restart; use Claude Code backend for long sessions |
+| **No `/compact`** | Context window fills up over long conversations | `/compact` → toast: "Context compaction not available on pydantic-ai backend." | Start fresh agent; manually summarize; future phase will add summarization |
+| **No file checkpointing** | No `/rewind` support | `/rewind` → toast: "File checkpointing not available on pydantic-ai backend." | Use git for undo |
+| **No permission mode cycling** | Shift+Tab has no effect | Shift+Tab → grey out mode indicator + toast: "Permission modes not available on pydantic-ai backend. Guardrails rules still enforce safety." | Guardrails rules still enforce safety; manual approval via `request_override` |
+| **No real-time tool streaming** | Tool results appear after completion (not streamed line-by-line) | Slightly delayed tool result display | Functional but slightly different UX from Claude Code |
+| **Model quality varies** | Cheaper/smaller models make more mistakes in multi-agent workflows | More retry prompts, occasional broken tool calls | Use capable models (GPT-4o, Gemini 2.5 Pro) for Coordinator agents |
+| **No WebSearch/WebFetch/NotebookEdit** | Only 7 core tools + orchestration tools available | LLM may hallucinate unavailable tools (mitigated by system prompt) | Use Bash + curl for web; edit notebooks manually |
+| **No image input** | pydantic-ai supports images but integration not in Phase 1 | Image paste → toast: "Image input not available on pydantic-ai backend." | Use Claude Code backend for image tasks |
+| **Token tracking approximate** | pydantic-ai reports tokens differently from Claude Code | Usage bar may be less accurate | Informational only |
+| **No SLURM/LSF MCP tools** | Template MCP tools are Claude Code-only | Tools not available; use Bash instead | `sbatch`, `bsub` via Bash tool |
+
+### First-Launch Banner
+
+On the first launch with the pydantic-ai backend, show an informational banner:
+
+```
+╭─────────────────────────────────────────────────────╮
+│ Running with pydantic-ai backend (openai:gpt-4o)    │
+│                                                     │
+│ Available: Read, Write, Edit, Bash, Glob, Grep, Ls  │
+│           Multi-agent, Workflows, Guardrails        │
+│                                                     │
+│ Not available: /resume, /compact, /rewind,          │
+│   WebSearch, WebFetch, NotebookEdit, images         │
+│                                                     │
+│ Run /backend for current backend status.            │
+╰─────────────────────────────────────────────────────╯
+```
+
+Add `/backend` command that shows current backend type, model, available tools,
+and known limitations.
+
+---
+
+## 12. Risks & Mitigations
+
+### R1: Streaming Impedance Mismatch (HIGH)
+
+**Risk:** Claude Code streams tool results in real-time (you see a file being
+read line by line). pydantic-ai's tool execution is synchronous — the tool runs
+to completion, then returns the full result. This creates a UX difference.
+
+**Mitigation:** The TUI already handles non-streaming tool results (it shows the
+collapsible widget, then fills in output when `on_tool_result` fires). The only
+difference is timing — results appear slightly later. Accept this as a Phase 1
+limitation; Phase 2 could add chunked tool output emission.
+
+### R2: Cancellation / Interrupt Race Conditions (HIGH)
+
+**Risk:** When the user presses Escape to interrupt, `agent.interrupt()` sets a
+cancel event and exits the `agent.iter()` async context. But pydantic-ai may be
+mid-tool-execution (e.g., a Bash command running). The tool's subprocess needs
+cleanup.
+
+**Mitigation:** Tool implementations must handle `asyncio.CancelledError`
+gracefully — kill subprocesses, close file handles. The Bash tool should use
+`try/finally` with `proc.kill()`. pydantic-ai's context manager cleanup should
+handle most cases; add explicit subprocess tracking as defense in depth.
+
+### R3: Conversation History Desync (MEDIUM)
+
+**Risk:** Claudechic maintains its own `Agent.messages: list[ChatItem]` for TUI
+rendering. pydantic-ai maintains `message_history: list[ModelMessage]` for LLM
+context. These could diverge if errors occur mid-conversation.
+
+**Mitigation:** The pydantic-ai backend is the source of truth for LLM history.
+Claudechic's `ChatItem` list is for display only. After each `send_and_stream`
+completes, update `self._messages = agent_run.result.all_messages()`. On error,
+the pydantic-ai history rolls back naturally (the failed turn isn't added).
+
+### R4: Tool Argument Validation with Weaker Models (MEDIUM)
+
+**Risk:** Smaller models (Ollama, GPT-4o-mini) may produce malformed tool
+arguments — wrong types, missing required fields, invalid JSON. Claude Code
+handles retries internally; pydantic-ai uses `ModelRetry` + retry count.
+
+**Mitigation:** pydantic-ai validates tool arguments via Pydantic models
+(automatic from function signatures). Invalid arguments trigger automatic
+retries (configurable via `retries=` parameter, default 1). Set retries=2 for
+file tools with weaker models.
+
+### R5: pydantic-ai API Instability (MEDIUM)
+
+**Risk:** pydantic-ai is actively developed (v1.80.0). The `Agent.iter()` API,
+hook system, or toolset interface could change in future versions.
+
+**Mitigation:** Pin `pydantic-ai>=1.80.0,<1.90.0` in optional dependencies
+(tighter than `<2.0.0` to catch minor-version API changes). The integration is
+contained to a single file (`pydantic_ai_backend.py` + `chic_toolset.py`), so
+API changes only affect ~370 lines. Add **weekly CI job** running against latest
+pydantic-ai to detect breakage early. Wait 2-4 weeks after v1.80.0 before
+starting implementation.
+
+### R6: Guardrail Hook Timing (LOW)
+
+**Risk:** Claude Code's guardrails evaluate *before* the tool runs (PreToolUse
+hook). pydantic-ai's `before_tool_execute` fires at the same point. But
+pydantic-ai handles tool arguments as already-parsed dicts, while Claude Code
+may pass raw strings. Pattern matching on `detect_field` must work identically.
+
+**Mitigation:** Both paths use the same `_get_field()` + `detect_pattern.search()`
+logic from `guardrails/rules.py`. The pure function doesn't care about the
+calling context. Test with both backends to verify identical rule matching.
+
+### R7: Cost Overrun with API Backends (LOW)
+
+**Risk:** Users on OpenAI/Gemini API pay per token. Long multi-agent workflows
+could generate unexpected bills, unlike Claude Max subscription (flat rate).
+
+**Mitigation:** Expose pydantic-ai's `UsageLimits` via config:
+```yaml
+pydantic_ai:
+  usage_limits:
+    request_limit: 50
+    response_tokens_limit: 100000
+```
+Show running cost estimate in the status footer (pydantic-ai reports cost
+if the model supports it).
+
+### R8: Private SDK Attribute Breakage (CRITICAL)
+
+**Risk:** `ClaudeCodeBackend` accesses private SDK attributes for subprocess
+management: `client._query.transport._process.pid` (in `_is_transport_alive`
+and `_sigint_fallback`), and `client._transport.write()` (for image messages).
+These are undocumented internals that could change in any `claude-agent-sdk`
+release without warning.
+
+**Mitigation:**
+- Write **characterization tests** that verify these private attribute paths
+  exist and behave as expected BEFORE starting the extraction refactor.
+- Wrap each private attribute access in a try/except with graceful degradation.
+- File feature request with claude-agent-sdk for public API equivalents
+  (get_subprocess_pid, send_raw_message).
+- Allocate extra time: **3 days** for ClaudeCodeBackend (was 1 day) to account
+  for discovery of additional private attribute usage.
+
+### R9: Fire-and-Forget Message Loss (HIGH)
+
+**Risk:** `_send_prompt_fire_and_forget()` in `mcp.py:116-154` creates an
+asyncio task that calls `agent.send(prompt)`. If the agent is busy (already
+processing a response), the message is queued in `_pending_messages`. With the
+pydantic-ai backend, if the agent disconnects or errors mid-response, queued
+messages are lost silently.
+
+**Mitigation:** Add logging when pending messages are dropped during disconnect.
+Consider adding a `drain_on_error` flag to replay queued messages after error
+recovery. For Phase 1, accept this limitation with explicit logging.
+
+### R10: NFS / Filesystem Latency (MEDIUM)
+
+**Risk:** This project runs on HPC cluster NFS. File operations (Read, Write,
+Edit, Glob, Grep) may block the event loop on NFS latency spikes (100ms+
+typical, seconds under load). Claude Code handles this in its subprocess; our
+local tools run in-process.
+
+**Mitigation:** All file I/O wrapped in `asyncio.to_thread()` (see Section 5
+tool implementations). Avoid `os.stat()` calls in hot paths. Set generous
+timeouts for Glob/Grep operations. Add NFS-specific integration tests if
+possible.
+
+### R11: Context Window Exhaustion (MEDIUM-HIGH)
+
+**Risk:** Without `/compact`, long conversations on pydantic-ai backend will
+hit context window limits. Different models have vastly different context sizes
+(GPT-4o: 128K, Ollama models: 8-32K). There is no automatic recovery.
+
+**Mitigation:**
+- Track token usage in `CompleteEvent` and show context bar in TUI (same as
+  Claude Code path).
+- Emit `ErrorEvent(code="context_overflow")` when the API returns a context
+  error — TUI shows "Context window full. Start a new agent."
+- Phase 2 will add client-side summarization for pydantic-ai backend.
+- For Ollama/small models, recommend starting new agents frequently.
+
+### R12: Concurrent Tool Execution Race Conditions (MEDIUM)
+
+**Risk:** pydantic-ai may execute multiple tools concurrently in a single
+`CallToolsNode`. If two tools write to the same file simultaneously (e.g.,
+two Edit calls), results are undefined.
+
+**Mitigation:** Phase 1 tools use synchronous-style execution (one at a time
+via `asyncio.to_thread`). pydantic-ai's default is sequential tool execution.
+If parallel execution is enabled in future, add file-level locking in the
+toolset.
+
+### R13: API Key Exposure in Config (LOW-MEDIUM)
+
+**Risk:** Users may put raw API keys in `.claudechic.yaml` which could be
+committed to version control.
+
+**Mitigation:**
+- Support `${ENV_VAR}` expansion syntax so keys stay in environment variables.
+- Add `.claudechic.yaml` to the project's `.gitignore` template.
+- At startup, warn if `api_key` field contains a literal key (not an env var
+  reference).
+- Document best practice: always use environment variables for API keys.
+
+---
+
+## 13. Effort Estimate
+
+### Component Breakdown
+
+| Component | LOC | Time (days) | Notes |
+|-----------|-----|-------------|-------|
+| `backends/protocol.py` + event types + canonical types | 120 | 0.5 | Protocol + dataclasses + ToolUseData/ToolResultData |
+| `backends/claude_code.py` | 200 | **3** | Extract from agent.py; **private SDK attrs = high risk**; characterization tests first |
+| `backends/pydantic_ai_backend.py` | 350 | **3** | Core integration; iter() + streaming + arg accumulation + permissions |
+| `backends/tools/filesystem.py` | 300 | 2 | Read/Write/Edit/Glob/Grep; needs testing; NFS considerations |
+| `backends/tools/shell.py` | 100 | 0.5 | Bash/Ls |
+| `backends/tools/chic_toolset.py` + `mcp_impl.py` | 350 | **1.5** | Extract from mcp.py; dual registration; app injection |
+| `agent.py` modifications | 150 | **2** | Replace SDK types; refactor _process_response; drain logic to backend; PermissionRequestEvent handling |
+| `agent_manager.py` modifications | 40 | 0.5 | Factory pattern |
+| `app.py` modifications | 60 | 0.5 | Config + backend selection |
+| `messages.py` + widget SDK type replacement | 50 | **1** | ToolUseData/ToolResultData swap across messages.py, chat_view.py, tools.py, tool_protocol.py |
+| Guardrails hook adapter + permission bridge | 80 | **1** | pydantic-ai hook wrapper + interactive permissions |
+| Config + CLI flags + onboarding | 30 | 0.5 | .claudechic.yaml + argparse + first-launch banner |
+| `pyproject.toml` + packaging | 5 | 0.25 | Optional dependency |
+| Tests: characterization (ClaudeCodeBackend) | 100 | 1 | Verify private SDK attrs before refactoring |
+| Tests: security (path traversal, bash, OOM) | 150 | 1 | Path escape, file size, output truncation |
+| Tests: guardrail parity | 100 | 0.5 | Same rules produce same results on both backends |
+| Tests: error propagation | 50 | 0.5 | ErrorEvent handling, recovery flows |
+| Tests: integration + protocol | 200 | 1 | Backend protocol, tools, multi-agent |
+| Edge cases + debugging | — | 2 | Streaming, cancellation, error handling |
+| Security hardening | — | 1 | NFS edge cases, output limits, key exposure warnings |
+| **Total** | **~2440** | **~24 days** | |
+
+### Working Prototype vs Production-Hardened
+
+| Milestone | Scope | Time |
+|-----------|-------|------|
+| **Prototype** | Backend protocol + Claude Code adapter (with characterization tests) + pydantic-ai adapter + 3 tools (Read, Edit, Bash) + chic toolset. Single model, no guardrails/permissions. | ~9 days |
+| **Functional** | All 7 tools, guardrails integration, permission bridge, config system, multi-agent working. Basic testing. | ~17 days |
+| **Production** | Full test suite (characterization + security + parity + integration), error handling, edge cases, NFS hardening, onboarding UX, cost tracking, UsageLimits. | ~24 days |
+
+---
+
+## 14. Future Phases (Out of Scope for Phase 1)
+
+### Phase 2: Session Persistence & Compaction
+
+- Implement conversation history serialization for pydantic-ai backend
+- Save/restore `message_history` to `.chicsessions/` format
+- Implement context compaction (summarize old messages to free tokens)
+- Enable `/resume` for pydantic-ai sessions
+
+### Phase 3: Enhanced Tool Parity
+
+- Implement WebSearch, WebFetch (via pydantic-ai MCP client or direct HTTP)
+- Implement NotebookEdit (Jupyter cell manipulation)
+- Image input support for multi-modal models
+- File checkpointing (git-based snapshots for `/rewind`)
+
+### Phase 4: Ollama "Lite Mode"
+
+- Optimized configuration for local models (smaller context, fewer tools)
+- Automatic tool filtering based on model capability
+- Reduced system prompt for smaller context windows
+- Local-only mode with no API calls
+
+### Phase 5: MCP Server Mode
+
+- Expose claudechic as an MCP server that Cursor/Cline/other editors consume
+- Clients call claudechic's workflow/guardrails/multi-agent tools via MCP
+- Editor-agnostic workflow orchestration
+
+### Phase 6: Feature Parity Matrix
+
+| Feature | Claude Code | pydantic-ai (Phase 1) | pydantic-ai (Full) |
+|---------|------------|----------------------|-------------------|
+| Core tools (Read/Write/Edit/Bash/Glob/Grep) | ✅ | ✅ | ✅ |
+| Multi-agent | ✅ | ✅ | ✅ |
+| Workflows/Phases | ✅ | ✅ | ✅ |
+| Guardrails | ✅ | ✅ | ✅ |
+| Interactive permissions | ✅ | ✅ | ✅ |
+| Session resume | ✅ | ❌ | ✅ (Phase 2) |
+| Context compaction | ✅ | ❌ | ✅ (Phase 2) |
+| File checkpointing | ✅ | ❌ | ✅ (Phase 3) |
+| Permission modes | ✅ | ❌ | ⚠️ (partial) |
+| Web tools | ✅ | ❌ | ✅ (Phase 3) |
+| Image input | ✅ | ❌ | ✅ (Phase 3) |
+| MCP server mode | ❌ | ❌ | ✅ (Phase 5) |
+| 15+ LLM providers | ❌ | ✅ | ✅ |
+| Local models (Ollama) | ❌ | ✅ | ✅ |
+| Cost control | ❌ | ✅ | ✅ |
+
+---
+
+## Appendix A: File Reference
+
+All paths relative to `submodules/claudechic/claudechic/`:
+
+| File | Key Functions | SDK Coupling Level |
+|------|--------------|-------------------|
+| `agent.py` | `Agent.connect()` (L287), `Agent._process_response()` (L750), `Agent._handle_sdk_message()` (L939), `Agent.interrupt()` (L536) | DEEP — primary refactor target |
+| `agent_manager.py` | `AgentManager.__init__` (L32), `AgentManager.create()` (L120), `AgentManager.connect_agent()` (L173) | MODERATE — factory pattern change |
+| `app.py` | `ChatApp._make_options()` (L719), `ChatApp.on_mount()` (L770), `ChatApp._merged_hooks()` | MODERATE — config + factory |
+| `mcp.py` | `_make_spawn_agent()` (L157), `_send_prompt_fire_and_forget()` (L116), `create_chic_server()` | MODERATE — tool extraction |
+| `guardrails/hooks.py` | `create_guardrail_hooks()` (L36), `evaluate()` (L60) | MODERATE — hook adapter |
+| `protocols.py` | `AgentObserver`, `AgentManagerObserver`, `PermissionHandler` | LIGHT — type import swap; `on_system_message` signature update |
+| `messages.py` | `ResponseComplete`, `ToolUseMessage`, `ToolResultMessage` | LIGHT — replace SDK types with canonical `ToolUseData`/`ToolResultData` |
+| `widgets/content/tools.py` | `ToolUseWidget`, tool rendering | LIGHT — runtime `ToolUseBlock`/`ToolResultBlock` imports → canonical types |
+| `widgets/base/tool_protocol.py` | `ToolWidget.update_result()` | LIGHT — `ToolResultBlock` in signature → `ToolResultData` |
+| `widgets/layout/chat_view.py` | `ChatView._append_tool_use()` (L293), `ChatView._handle_tool_result()` (L351) | LIGHT — constructs `ToolUseBlock` at runtime → `ToolUseData` |
+| `workflows/agent_folders.py` | `assemble_phase_prompt()` | LIGHT — imports `HookMatcher` from SDK |
+| `enums.py` | `ToolName`, `AgentStatus`, `ResponseState` | NONE — already backend-agnostic |
+| `workflows/` (other modules) | All modules | NONE — already backend-agnostic |
+| `guardrails/rules.py` | All functions | NONE — pure functions |
+| `guardrails/hits.py` | `HitLogger`, `HitRecord` | NONE — pure functions |
+| `features/worktree/` | All functions | NONE — pure git operations |
+| `sessions.py` | All functions | NONE — pure file I/O |
+| `formatting.py` | All functions | NONE — pure functions |
+| `file_index.py` | `FileIndex` | NONE — git ls-files |
+
+**Test files requiring SDK import updates:**
+- `tests/test_agent_permission.py` — imports `ToolUseBlock` etc.
+- `tests/test_app_ui.py` — imports SDK message types
+- `tests/test_widgets.py` — imports SDK block types
+
+## Appendix B: pydantic-ai API Surface Used
+
+| pydantic-ai API | Used For | Stable? |
+|----------------|----------|---------|
+| `Agent(model, toolsets=, hooks=, system_prompt=)` | Create LLM agent | ✅ Core API |
+| `Agent.iter(prompt, message_history=)` | Node-by-node run | ✅ Core API |
+| `Agent.is_model_request_node()` | Node type checking | ✅ Core API |
+| `Agent.is_call_tools_node()` | Node type checking | ✅ Core API |
+| `node.stream(ctx)` | Streaming from nodes | ✅ Core API |
+| `PartDeltaEvent`, `PartStartEvent` | Stream event types | ✅ Core API |
+| `FunctionToolset` | Tool registration | ✅ Core API |
+| `Hooks.on.before_tool_execute` | Guardrails + permissions hook | ✅ Core API |
+| `Hooks.on.after_tool_execute` | Result emission | ✅ Core API |
+| `SkipToolExecution` | Block tool call | ✅ Core API |
+| `UsageLimits` | Token/request limits | ✅ Core API |
+| `FallbackModel` | Model fallback | ✅ Core API |
+| `RunUsage` | Token usage reporting | ✅ Core API |
+| `ModelSettings` | Temperature, max_tokens | ✅ Core API |
+
+All APIs used are from pydantic-ai's documented core — no private APIs or
+undocumented features. (Note: `ClaudeCodeBackend` does access private
+`claude-agent-sdk` attributes — see R8.)
+
+---
+
+## Amendment Log
+
+**2026-04-11 — Fresh Architecture Review**
+
+Four independent reviewers analyzed the spec against the actual codebase.
+The following amendments were incorporated:
+
+### Critical Additions
+1. **Permission system for pydantic-ai backend** (Section 7b) — Added
+   `PermissionRequestEvent`, `PermissionBridge` class, and integration with
+   `_process_response()`. Without this, pydantic-ai would auto-approve all tools.
+2. **Tool argument accumulation** (Section 4, PydanticAIBackend) — Replaced
+   empty `input={}` with proper `PartDeltaEvent` argument accumulator that
+   collects `args_delta` JSON incrementally and emits `ToolUseEvent` only
+   when complete.
+3. **Bash/file tool security hardening** (Section 5) — Added 10MB file size
+   cap, 30K char output truncation, NFS latency considerations with
+   `asyncio.to_thread()`.
+4. **4 missed files** (Section 3, Appendix A) — Added `widgets/content/tools.py`,
+   `widgets/base/tool_protocol.py`, `widgets/layout/chat_view.py`,
+   `workflows/agent_folders.py` to modification list with correct SDK coupling.
+5. **ClaudeCodeBackend extraction risk** (Section 4, R8) — Documented private
+   SDK attribute access, mandated characterization tests, increased estimate
+   from 1 to 3 days.
+
+### High-Priority Additions
+6. **`ErrorEvent`** (Section 4) — Added to `BackendEvent` union with `code`,
+   `message`, `recoverable`, `retry_after_ms` fields. Added error handling
+   behavior table and exception translation.
+7. **Unsupported command UX** (Section 11) — Added "User Experience" column
+   specifying toast messages for each unavailable feature.
+8. **Testing budget** (Section 13) — Increased from 2 days/200 LOC to
+   4 days/500 LOC across 4 categories: characterization, security, parity,
+   integration.
+9. **`_app` global extraction** (Section 6) — Added `register_app()` pattern
+   and `_require_app()` helper for shared implementation module.
+10. **Onboarding guide** (Section 9) — Added "Getting Started with Alternative
+    Backends" quick start.
+11. **pydantic-ai pin** (Sections 1, 9, R5) — Tightened to `>=1.80.0,<1.90.0`.
+    Added weekly CI and 2-4 week wait recommendation.
+12. **Risks R8-R13** (Section 12) — Added: private SDK breakage (Critical),
+    fire-and-forget message loss (High), NFS latency (Medium), context exhaustion
+    (Medium-High), concurrent tool races (Medium), API key exposure (Low-Medium).
+13. **Revised effort** (Section 13) — Total increased from 15 to 24 days.
+14. **`send_and_stream()` image support** (Section 4) — Updated signature to
+    accept `images: list[bytes] | None`.
+15. **Widget SDK type replacement** (Sections 3, 4) — Added `ToolUseData` and
+    `ToolResultData` canonical dataclasses. Detailed widget file changes.
+16. **Test file modifications** (Section 3, Appendix A) — Listed test files
+    needing SDK import updates.
+17. **Template MCP tools** (Section 9) — Noted `slurm.py`/`lsf.py` remain
+    Claude Code-only.
+18. **LLM tool hallucination** (Section 4) — Added system prompt in
+    `PydanticAIBackend` explicitly listing available/unavailable tools.
+19. **First-launch banner** (Section 11) — Added info banner design and
+    `/backend` command.
+20. **Function name fix** — Corrected `_make_sdk_options()` to `_make_options()`
+    throughout (actual name in app.py L719).

--- a/.project_team/backend_decoupling/STATUS.md
+++ b/.project_team/backend_decoupling/STATUS.md
@@ -1,0 +1,22 @@
+# Project: backend_decoupling
+# Phase: setup
+# Status: initializing
+
+## Vision (Approved)
+
+| | |
+|---|---|
+| **Goal** | Explore and design approaches to decouple the claudechic workflow engine from the Claude Code API, enabling it to run on alternative AI backends. |
+| **Value** | Extends the audience beyond Claude Code users, making the workflow/phase system available to the broader AI-assisted development community. |
+| **Domain Terms** | **claudechic** — the workflow/phase orchestration system; **backend** — the AI agent runtime (currently Claude Code); **MCP tools** — the interface layer for agent spawning, phase management, etc. |
+| **Success looks like** | A clear understanding of coupling points, a set of viable decoupling strategies ranked by effort/impact, and a prototype or architecture plan for at least one alternative backend. |
+| **Failure looks like** | A vague report with no actionable paths forward, or a design that breaks existing Claude Code functionality without a clear migration story. |
+
+## Team
+- [ ] Leadership agents (not yet spawned)
+- [ ] Researcher (key role — requested by user)
+
+## Notes
+- User emphasized Researcher agent will be important
+- Focus on identifying coupling points between claudechic and Claude Code
+- Explore alternative AI coding assistants and direct LLM APIs

--- a/.project_team/backend_decoupling/userprompt.md
+++ b/.project_team/backend_decoupling/userprompt.md
@@ -1,0 +1,3 @@
+# User Prompt
+
+I want to know if we can run this AI project template with other backends that are not Claude Code. I want the team to think of different approaches to detach claudechic from the Claude Code API and see if we can use other APIs as backend. Researcher will be important for that. The goal would be to extend the audience beyond Claude Code users.

--- a/.project_team/bootstrapping_bridge/STATUS.md
+++ b/.project_team/bootstrapping_bridge/STATUS.md
@@ -1,0 +1,26 @@
+# Project: bootstrapping_bridge
+## Phase: specification (approved)
+## Status: advancing_to_implementation
+
+### Vision (approved)
+Design the bootstrapping bridge — a mechanism that connects what the Copier questionnaire collects at template generation time with the runtime workflows that act on it. Solve generically for cluster setup, git setup, codebase integration, and future setup concerns.
+
+### Identified Seams
+1. Cluster setup (Copier asks ssh_target → workflow re-detects from scratch)
+2. Git setup (Copier runs git init → no trigger for remote setup)
+3. Existing codebase integration (Copier integrates → no workflow for late addition)
+4. Claudechic mode (standard vs developer, no transition path)
+5. Quick start presets → feature discovery mismatch
+6. MCP tools availability (conditional generation, no late addition)
+
+### Key Design Questions
+1. State handoff: How does Copier output become workflow input?
+2. Trigger mechanism: What activates setup workflows?
+3. Skip vs re-verify: Adapt to pre-existing config?
+4. Late addition: Add features skipped at Copier time?
+5. Single orchestrator vs independent workflows?
+
+### Reference
+- PR #18: https://github.com/sprustonlab/AI_PROJECT_TEMPLATE/pull/18
+- Template entry: copier.yml
+- Activate script: template/activate.jinja

--- a/.project_team/bootstrapping_bridge/specification/APPENDIX.md
+++ b/.project_team/bootstrapping_bridge/specification/APPENDIX.md
@@ -1,0 +1,43 @@
+# Bootstrapping Bridge Specification — Appendix
+
+## A. Resolved Design Decisions
+
+These decisions were debated during the specification process and are recorded here for context.
+
+1. **SSH latency:** Synchronous/blocking. One-time check at session start. Simplicity over optimization.
+
+2. **Queue on manual stop:** Skip to next. If user stops a queued workflow, auto-advance to the next one. Queue only clears when empty.
+
+3. **Dismiss scope:** Permanent forever. "Don't show again" means never show again. No reset on `copier update`. User can run facet workflows manually.
+
+4. **No bridge file.** `.copier-answers.yml` is used directly via the existing `CopierAnswers` class. No `bridge.yaml` or `project_state.yaml`.
+
+5. **No claudechic core manifest changes.** The onboarding system does not add keys to workflow manifests (`concern:`, `copier_keys:`, `skip_when:` were all considered and rejected). The facet map is hardcoded in the session-start check. One-way dependency: onboarding knows about facet workflows; facet workflows know nothing about onboarding.
+
+6. **No onboarding workflow.** Onboarding is a session-start prompt, not a workflow or MCP tool. Earlier designs included `workflows/onboarding/` with role files, an `mcp_tools/onboarding.py` tool, and an `/onboard` slash command — all removed in favor of the simpler prompt-and-queue model.
+
+7. **No workflow_queue.** Considered a general-purpose `workflow_queue` MCP tool (~70 lines) for chaining facet workflows within a single session. Rejected because: (a) the session-start check already computes "what's next" from ground truth each session, making queue state redundant, (b) marathon multi-workflow sessions accumulate context and cause user fatigue, (c) one facet per session is natural and keeps context windows fresh. The welcome screen + idempotent health checks provide the sequencing for free.
+
+8. **Welcome screen over prompt.** The original session-start check was a three-option prompt (yes/not now/don't show). Replaced with a visual checklist that shows status of ALL facets (configured and unconfigured), gives the user full choice of which to work on, and provides a richer first-session experience. Same dismiss semantics, better UX.
+
+## B. Low-Priority Informational Facets
+
+These facets have no facet workflow and are not part of the onboarding queue. They are informational only.
+
+| Facet | Copier Key | Runtime State | Notes |
+|-------|-----------|--------------|-------|
+| Claudechic mode | `claudechic_mode` | standard or developer | No transition path exists today. |
+| Content preset | `quick_start` | Which files exist | One-shot at generation. `copier update` to change. |
+| MCP tools | `use_cluster` | Files in `mcp_tools/` | Both backends + single `cluster.yaml` ship when `use_cluster=true`. Bundled with cluster facet. |
+
+## C. Pattern Mining
+
+Pattern mining (`mine-patterns` command, `scripts/mine_patterns.py`) analyzes Claude Code session history for recurring corrections and should become a proper workflow (`/pattern-mining`). It is **not an onboarding facet** — it requires session history to exist, so it cannot run at project setup time. It is a separate effort outside this spec's scope.
+
+## D. Spec Version History
+
+1. **Initial design:** Generic bootstrapping bridge with `project_state.yaml`, per-concern protocol, self-describing manifest keys (`concern:`, `copier_keys:`, `skip_when:`), and claudechic core ManifestLoader changes.
+2. **Onboarding MCP + workflow:** Replaced bridge file with onboarding MCP tool + dedicated onboarding workflow with role files and facet map in YAML.
+3. **Session-start prompt + queue:** Eliminated onboarding workflow and MCP tool entirely. Onboarding became a session-start check that queues standalone facet workflows via `workflow_queue`.
+4. **Copier simplification:** Reduced Copier to intent-only bools. Removed `cluster_scheduler`, `cluster_ssh_target`, `existing_codebase` (path), `codebase_link_mode`. Unified `lsf.yaml`/`slurm.yaml` into single `cluster.yaml`.
+5. **Welcome screen:** Eliminated `workflow_queue` entirely. Replaced the yes/not-now/dismiss prompt with a visual welcome screen showing a checklist of facet statuses. User selects which facet to work on (full agency, no forced ordering). One facet per session; welcome screen reappears with updated status each session. Reduced core changes from ~150 lines to ~100-130 lines.

--- a/.project_team/bootstrapping_bridge/specification/SPECIFICATION.md
+++ b/.project_team/bootstrapping_bridge/specification/SPECIFICATION.md
@@ -1,0 +1,455 @@
+# Bootstrapping Bridge Specification
+
+## 1. Problem Statement
+
+The AI_PROJECT_TEMPLATE has a two-phase onboarding that currently has a seam between the phases:
+
+1. **Copier** (generation time) asks intent questions (`use_cluster?`, `init_git?`, `use_existing_codebase?`), generates config stubs, and exits.
+2. **Runtime workflows** (after activation) re-detect everything from scratch, ignoring what Copier already collected.
+
+The user experiences this as redundant questioning, disconnected setup steps, and no unified view of what's configured vs. what still needs attention. Six specific seams exist today:
+
+| Seam | Copier Side | Runtime Side | Gap |
+|------|------------|--------------|-----|
+| Cluster | Asks intent only (`use_cluster`); generates both MCP backends | cluster_setup workflow handles SSH target, scheduler detection, config | Copier generates files; workflow configures them |
+| Git | Runs `git init` + initial commit | `/git_setup` skill exists but is disconnected | No trigger for remote setup |
+| Codebase | Asks path + link mode, integrates at generation | No workflow for late addition | One-shot, non-interactive |
+| Claudechic mode | standard vs developer choice | No transition path | Mode locked at generation |
+| Quick-start presets | Conditional file generation | Workflows may assume features exist | No runtime awareness of what was included |
+| MCP tools | Conditionally generated | No way to add tools later | One-shot only |
+
+## 2. Solution: Welcome Screen
+
+### Mental Model
+
+Onboarding is a **welcome screen** — a UI panel that appears at session start, shows a checklist of setup items with live status, and lets the user choose which one to work on.
+
+```
+Session starts
+  -> claudechic reads .copier-answers.yml (CopierAnswers, already exists)
+  -> checks real state: SSH works? git remote exists? codebase integrated?
+  -> builds checklist of setup items with status
+  -> if any incomplete: renders welcome screen
+  -> user picks one -> that facet workflow activates, welcome screen closes
+  -> OR user closes/skips -> screen goes away, reappears next session
+  -> OR user clicks "Don't show again" -> permanent dismiss
+  -> next session: welcome screen reappears with updated status
+  -> when everything is configured: welcome screen doesn't appear
+```
+
+No `/onboard` command. No onboarding workflow. No MCP tool. No workflow queue. A visual checklist that the user interacts with directly.
+
+### Key Design Decisions
+
+1. **`.copier-answers.yml` is the only bridge.** The `CopierAnswers` class already exists in claudechic core. Copier records intent (bool flags); facet workflows handle details interactively.
+
+2. **Copier asks intent, workflows handle details.** A consistent pattern across all three facets: Copier asks a single bool (`use_cluster`, `init_git`, `use_existing_codebase`) and generates files. Workflows handle interactive configuration (SSH targets, scheduler detection, remote URLs, codebase paths, link modes). This reduces Copier questions from 15 to 12.
+
+3. **Onboarding is a welcome screen, not a workflow.** It renders once at session start, shows status, and lets the user pick. No persistent onboarding state beyond a dismiss marker.
+
+4. **User chooses which facet to work on.** The welcome screen presents all incomplete facets. The user selects one. No forced ordering, no auto-start. Full agency.
+
+5. **One facet per session.** After the user selects a facet workflow and completes it, the session ends naturally. The next session's welcome screen shows updated status with the completed facet checked off. This keeps context windows fresh and avoids marathon setup sessions.
+
+6. **Facet workflows are standalone.** `cluster-setup` (PR #18), `git-setup` (new), and `codebase-setup` (new) are independent workflows. They don't know about onboarding. They can be run at any time via their own slash commands.
+
+7. **Workflows always re-verify.** Copier answers are hints, not truth. The welcome screen probes actual state (SSH connectivity, git remote existence). Facet workflows re-validate everything.
+
+8. **Three-option dismiss model.** The welcome screen offers: select a facet (run it), close/skip (reappears next session), "Don't show again" (permanent dismiss, never shown again).
+
+9. **Facet map is hardcoded.** The welcome screen logic hardcodes which CopierAnswers keys map to which facet workflows (~15 lines). No config file, no manifest discovery.
+
+## 3. Terminology
+
+| Term | Definition |
+|------|-----------|
+| **Onboarding** | The welcome screen that detects incomplete setup and lets the user pick a facet workflow |
+| **Welcome screen** | The UI panel/overlay rendered at session start showing setup status |
+| **Facet** | One independent setup concern (cluster, git, codebase) |
+| **Facet workflow** | A standalone workflow handling one facet (e.g., `cluster-setup`, `git-setup`, `codebase-setup`) |
+| **CopierAnswers** | The class that reads `.copier-answers.yml` |
+| **Dismiss marker** | Flag indicating the user chose "Don't show again" |
+
+## 4. Architecture
+
+### 4.1 Component Overview
+
+```
+.copier-answers.yml              <-- bridge (Copier writes, claudechic reads)
+claudechic core:
+  welcome screen widget           <-- reads CopierAnswers, checks state, renders checklist
+  dismiss marker                   <-- field in hints_state.json
+workflows/cluster_setup/          <-- facet workflow (PR #18, minor updates)
+  cluster_setup.yaml
+  cluster_setup_helper/
+    identity.md, detect.md, ...
+workflows/git_setup/              <-- facet workflow (new)
+  git_setup.yaml
+  git_setup_helper/
+    identity.md, init.md, remote.md, push.md, hooks.md
+workflows/codebase_setup/         <-- facet workflow (new)
+  codebase_setup.yaml
+  codebase_setup_helper/
+    identity.md, locate.md, integrate.md, environment.md, verify.md
+```
+
+### 4.2 Welcome Screen (claudechic core)
+
+Renders automatically when a new claudechic session begins and setup is incomplete.
+
+**Logic:**
+
+```python
+async def _check_onboarding(self) -> None:
+    """Session-start onboarding check. Reads CopierAnswers, probes real
+    state, and renders welcome screen if setup is incomplete."""
+
+    # 1. Bail out early
+    if self._onboarding_dismissed():
+        return
+    answers = CopierAnswers.load()  # returns None if no .copier-answers.yml
+    if answers is None:
+        return
+
+    # 2. Build checklist of facet statuses
+    facets: list[FacetStatus] = []  # (workflow_id, label, configured: bool, detail: str)
+
+    if answers.get("use_cluster"):
+        configured = self._cluster_configured()
+        detail = self._cluster_detail() if configured else "not configured"
+        facets.append(FacetStatus("cluster-setup", "Cluster access", configured, detail))
+
+    git_configured = self._git_remote_configured()
+    detail = self._git_detail() if git_configured else "no remote set"
+    facets.append(FacetStatus("git-setup", "Git remote", git_configured, detail))
+
+    if answers.get("use_existing_codebase"):
+        configured = self._codebase_configured()
+        detail = "integrated" if configured else "not integrated"
+        facets.append(FacetStatus("codebase-setup", "Codebase integration", configured, detail))
+
+    # 3. If everything is configured, don't show
+    if all(f.configured for f in facets):
+        return
+
+    # 4. Render welcome screen
+    choice = await self._show_welcome_screen(facets)
+    #   workflow_id     -> activate that workflow
+    #   "skip"          -> do nothing, show again next session
+    #   "dont_show"     -> write dismiss marker, never show again
+
+    if choice == "dont_show":
+        self._write_dismiss_marker()
+    elif choice == "skip":
+        pass  # welcome screen closes, normal session continues
+    else:
+        await self._activate_workflow(choice)  # choice is a workflow_id
+```
+
+**Welcome screen rendering:**
+
+```
+┌─────────────────────────────────────────────┐
+│  Welcome to your project! Setup status:     │
+│                                             │
+│  ○ Cluster access    — not configured       │
+│  ✔ Git remote        — origin → github/foo  │
+│  ○ Codebase integration — not integrated    │
+│                                             │
+│  Select an unconfigured item to set it up,  │
+│  or press [Skip] to start working.          │
+│                                             │
+│  [Skip]  [Don't show again]                 │
+└─────────────────────────────────────────────┘
+```
+
+- Configured items show ✔ with detail (e.g., "LSF on login.hpc.edu", "origin → github.com/user/repo").
+- Unconfigured items show ○ and are selectable (clickable or keyboard-navigable).
+- Selecting an unconfigured item activates that facet workflow and closes the welcome screen.
+- [Skip] closes the screen for this session. It reappears next session.
+- [Don't show again] writes the dismiss marker. Screen never appears again.
+
+**Health checks (called by the welcome screen logic):**
+
+| Facet | Check | "Configured" means |
+|-------|-------|-------------------|
+| cluster | `_cluster_configured()` | `mcp_tools/cluster.yaml` has non-empty `backend` AND non-empty `ssh_target` AND `ssh -o BatchMode=yes <target> echo ok` succeeds. OR local scheduler detected (`which bsub` or `which sbatch`). |
+| git | `_git_remote_configured()` | `.git/` exists AND `git remote get-url origin` succeeds |
+| codebase | `_codebase_configured()` | At least one non-hidden directory exists in `repos/` |
+
+**The checks run synchronously at session start.** SSH check has a 5-second timeout. If it times out, the facet is marked as needing setup. Git and codebase checks are local and instant.
+
+### 4.3 Workflow Activation from Welcome Screen
+
+When the user selects a facet, the welcome screen calls `_activate_workflow(workflow_id)`. This is the existing workflow activation mechanism, with one small change:
+
+**Bypass chicsession naming prompt.** When activated from the welcome screen, the workflow uses its workflow ID as the chicsession name automatically (e.g., "cluster-setup"). No interactive naming prompt.
+
+This requires a minor refactor to `_activate_workflow()` — add an optional `auto_name: str | None` parameter that, when provided, skips the naming prompt and uses the given name directly.
+
+### 4.4 Dismiss Marker
+
+When the user chooses "Don't show again", a dismiss marker is written as a field in `hints_state.json`: `{"onboarding_dismissed": true}`. This reuses existing infrastructure and is already managed atomically.
+
+**Dismiss is permanent.** No auto-reset. If the user dismisses and later runs `copier update`, they run facet workflows manually via slash commands.
+
+## 5. Facet Specifications
+
+### 5.1 Cluster Facet
+
+**Copier side:** Copier asks only `use_cluster` (bool). The `cluster_scheduler` (enum) and `cluster_ssh_target` (str) questions are removed from `copier.yml`. When `use_cluster == true`, Copier includes all cluster files: `_cluster.py`, `lsf.py`, `slurm.py`, and `mcp_tools/cluster.yaml`. Both backends ship; the workflow configures the appropriate one.
+
+**Single config file: `mcp_tools/cluster.yaml`** replaces the per-scheduler `lsf.yaml` + `slurm.yaml`:
+```yaml
+# mcp_tools/cluster.yaml -- single config, backend field selects scheduler
+backend: ""              # lsf | slurm -- detected by cluster-setup workflow
+ssh_target: ""           # filled by workflow
+lsf_profile: ""          # LSF-specific (e.g., /misc/lsf/conf/profile.lsf)
+watch_poll_interval: 30
+remote_cwd: ""
+path_map: []
+log_access: auto
+```
+
+**Copier `_exclude` changes:** The existing per-scheduler conditionals are replaced with a single `use_cluster` gate:
+```yaml
+# Before: per-scheduler exclusion (4 separate conditionals)
+- "{% if not use_cluster or cluster_scheduler != 'lsf' %}mcp_tools/lsf.py{% endif %}"
+# After: all cluster files gated on use_cluster only
+- "{% if not use_cluster %}mcp_tools/_cluster.py{% endif %}"
+- "{% if not use_cluster %}mcp_tools/lsf.py{% endif %}"
+- "{% if not use_cluster %}mcp_tools/slurm.py{% endif %}"
+- "{% if not use_cluster %}mcp_tools/cluster.yaml{% endif %}"
+```
+
+**Recommendation:** Consider merging `lsf.py` and `slurm.py` into a single `cluster.py` that dispatches based on the `backend` field in `cluster.yaml`. This is an implementation detail -- either approach works.
+
+**Facet workflow:** `cluster-setup` (PR #18, with updates to detect and apply phases). Seven phases:
+1. detect -- ask user for SSH target, test reachability
+2. ssh_auth -- verify passwordless SSH
+3. ssh_mux -- set up connection pooling
+4. scheduler -- detect which scheduler is available (LSF or SLURM), write `backend` field
+5. paths -- configure path mappings and remote_cwd
+6. validate -- end-to-end validation with real job
+7. apply -- write final config to `mcp_tools/cluster.yaml`
+
+**No pre-population:** Copier does not write `ssh_target` or `backend` into `cluster.yaml`. The workflow starts fresh. Copier generates files, workflow configures them.
+
+**Welcome screen check:** `use_cluster == true` in CopierAnswers AND `cluster.yaml` has empty `backend` or empty `ssh_target` or SSH fails AND no local scheduler detected -> show as unconfigured.
+
+**Independent usage:** `/cluster-setup` works at any time, outside of onboarding.
+
+### 5.2 Git Facet
+
+**Copier side:** `init_git == true` triggers `git init && git add -A && git commit -m "Initial project"` in `_tasks`. No remote setup.
+
+**Facet workflow:** `git-setup` (new standalone workflow). Never skipped by onboarding -- git is always relevant.
+
+```yaml
+# workflows/git_setup/git_setup.yaml
+workflow_id: git-setup
+main_role: git_setup_helper
+
+phases:
+  - id: init
+    file: init
+    hints:
+      - message: "Checking git initialization status..."
+        lifecycle: show-once
+    advance_checks:
+      - type: command-output-check
+        command: "git rev-parse --git-dir 2>/dev/null || echo no_git"
+        pattern: "\\.git"
+      - type: manual-confirm
+        prompt: "Git repository initialized?"
+
+  - id: remote
+    file: remote
+    hints:
+      - message: "Configuring git remote. Will offer to create a GitHub repo if needed."
+        lifecycle: show-once
+    advance_checks:
+      - type: command-output-check
+        command: "git remote get-url origin 2>/dev/null || echo no_remote"
+        pattern: "^(?!no_remote)"
+      - type: manual-confirm
+        prompt: "Git remote configured?"
+
+  - id: push
+    file: push
+    advance_checks:
+      - type: manual-confirm
+        prompt: "Initial commit pushed to remote?"
+
+  - id: hooks
+    file: hooks
+    advance_checks:
+      - type: manual-confirm
+        prompt: "Repository settings configured (or skipped)?"
+```
+
+**Phase details:**
+
+| Phase | What It Does | Auto-Fixable? |
+|-------|-------------|---------------|
+| **init** | Check `git rev-parse --git-dir`. If no repo, offer `git init && git add -A && git commit`. | Yes |
+| **remote** | Check `git remote get-url origin`. If none, detect `gh` CLI, offer `gh repo create --private`. Fall back to `git remote add`. | Partially (needs user auth) |
+| **push** | If remote exists but no upstream, run `git push -u origin main`. Handle branch naming. | Yes |
+| **hooks** | Optional: offer branch protection via `gh api`, configure `.githooks/`, set up pre-commit. User can skip. | Yes |
+
+**Welcome screen check:** Always checks git state. No remote -> show as unconfigured.
+
+**Independent usage:** `/git-setup` works at any time, outside of onboarding.
+
+### 5.3 Codebase Facet
+
+**Copier side:** Copier asks only `use_existing_codebase` (bool). No path, no link mode. Copier does NOT run `integrate_codebase.py` as a `_task`. The `existing_codebase` (str path) and `codebase_link_mode` (enum) questions are removed from `copier.yml`. The `_tasks` entry for codebase integration is removed. Copier just records the intent; the workflow does the work.
+
+**Facet workflow:** `codebase-setup` (new standalone workflow).
+
+```yaml
+# workflows/codebase_setup/codebase_setup.yaml
+workflow_id: codebase-setup
+main_role: codebase_setup_helper
+
+phases:
+  - id: locate
+    file: locate
+    hints:
+      - message: "Locating the existing codebase to integrate..."
+        lifecycle: show-once
+    advance_checks:
+      - type: manual-confirm
+        prompt: "Codebase path confirmed and validated?"
+
+  - id: integrate
+    file: integrate
+    hints:
+      - message: "Integrating codebase into repos/ directory..."
+        lifecycle: show-once
+    advance_checks:
+      - type: command-output-check
+        command: "ls -d repos/*/ 2>/dev/null | head -1"
+        pattern: "repos/"
+      - type: manual-confirm
+        prompt: "Codebase integrated into repos/?"
+
+  - id: environment
+    file: environment
+    hints:
+      - message: "Scanning codebase for dependencies and configuring environment..."
+        lifecycle: show-once
+    advance_checks:
+      - type: manual-confirm
+        prompt: "Environment configured and dependencies resolved?"
+
+  - id: verify
+    file: verify
+    advance_checks:
+      - type: manual-confirm
+        prompt: "Imports work and codebase is functional?"
+```
+
+**Phase details:**
+
+| Phase | What It Does | Auto-Fixable? |
+|-------|-------------|---------------|
+| **locate** | Ask user for codebase path. Validate it exists. Check if it's a git repo, a Python package, or a plain directory. Identify the top-level module name. | No (needs user input) |
+| **integrate** | Determine integration method: symlink (saves disk, changes reflect immediately) vs copy (works everywhere). Place in `repos/`. Validate the link/copy succeeded. | Yes |
+| **environment** | Scan codebase for `requirements.txt`, `setup.py`, `pyproject.toml`, `environment.yml`. Propose a pixi feature/environment with the discovered dependencies. Add `repos/<name>` to PYTHONPATH (activate script already handles this). | Partially |
+| **verify** | Test that `import <module>` works from the project root. If existing tests are found (`tests/`, `pytest.ini`), offer to run them. Report any import errors or missing dependencies. | Yes |
+
+**Welcome screen check:** `use_existing_codebase == true` in CopierAnswers AND no directory in `repos/` -> show as unconfigured.
+
+**Independent usage:** `/codebase-setup` works at any time, outside of onboarding.
+
+## 6. Late Addition
+
+When a user wants to add a facet that was skipped at generation time:
+
+1. Run `copier update` and change answers (e.g., `use_cluster: false` -> `true`, or `use_existing_codebase: false` -> `true`)
+2. Copier generates the previously-excluded files and updates `.copier-answers.yml`
+3. On next session, the welcome screen detects the new intent vs. unconfigured state
+4. If not dismissed: welcome screen shows the new facet as unconfigured alongside any others
+5. If dismissed: user runs the facet workflow manually (e.g., `/cluster-setup`, `/codebase-setup`)
+
+`copier update` handles file generation. Facet workflows handle configuration. The welcome screen handles detection for users who haven't dismissed it.
+
+## 7. Re-Entry
+
+### Within a session (chicsession handles it)
+
+User quits mid-cluster-setup. On resume:
+- Chicsession restores `cluster-setup` at whatever phase they were on
+- User continues from where they left off
+
+### Across sessions (welcome screen handles it)
+
+User completes cluster-setup, quits. Next session:
+- Welcome screen runs: cluster SSH works (✔), git remote missing (○)
+- Welcome screen shows updated checklist with cluster checked off
+- User selects git-setup to continue onboarding
+
+### Fully configured project
+
+Welcome screen finds everything configured. No screen shown. Invisible.
+
+## 8. Technical Constraints
+
+### Existing Infrastructure
+
+| Component | Location | How We Use It |
+|-----------|----------|---------------|
+| `CopierAnswers` class | claudechic core | Read `.copier-answers.yml` |
+| `_check_config_readiness()` | `mcp_tools/_cluster.py` | Pattern for cluster health check |
+| `WorkflowEngine` | claudechic core | Phase management for facet workflows |
+| `hints_state.json` | claudechic core | Store dismiss marker |
+| Chicsession persistence | claudechic core | Resume interrupted workflows |
+
+### Required Core Changes
+
+| Change | File | Description | Lines |
+|--------|------|-------------|-------|
+| Welcome screen widget | `widgets/` | Checklist UI with status, selection, skip, dismiss | ~50-80 |
+| Health check functions | `app.py` or `onboarding.py` | `_cluster_configured()`, `_git_remote_configured()`, `_codebase_configured()` | ~30 |
+| `_activate_workflow` refactor | `app.py` | Add `auto_name` parameter to bypass chicsession naming prompt | ~15 |
+| Dismiss marker | `app.py` | Write/read `onboarding_dismissed` in `hints_state.json` | ~5 |
+| Session-start hook | `app.py` | Call `_check_onboarding()` after manifest loading, before first input | ~5 |
+| **Total** | | | **~100-130** |
+
+## 9. Implementation Plan
+
+### Phase A: Copier Simplification
+
+1. Update `copier.yml`: remove `cluster_scheduler` and `cluster_ssh_target` questions
+2. Update `copier.yml`: replace `existing_codebase` (str path) + `codebase_link_mode` (enum) with `use_existing_codebase` (bool). Remove the `integrate_codebase.py` `_task`.
+3. Update `_exclude` in `copier.yml`: replace per-scheduler conditionals with single `use_cluster` gate
+4. Replace `lsf.yaml.jinja` + `slurm.yaml.jinja` with single `cluster.yaml.jinja` (empty `backend` and `ssh_target`)
+
+**Delivers:** Consistent intent-only Copier pattern across all facets. Questions reduced from 15 to 12. Template ready for the new workflows.
+
+### Phase B: Welcome Screen + Health Checks
+
+1. Implement health check functions: `_cluster_configured()`, `_git_remote_configured()`, `_codebase_configured()`
+2. Build welcome screen widget (checklist UI with status indicators, selection, skip, dismiss)
+3. Add permanent dismiss marker to `hints_state.json`
+4. Refactor `_activate_workflow()` to accept optional `auto_name` parameter
+5. Wire into session startup (call after manifest loading, before first user input)
+
+**Delivers:** Welcome screen appears at session start showing setup status. User selects a facet to work on, skips, or permanently dismisses.
+
+### Phase C: `git-setup` Facet Workflow
+
+1. Create `workflows/git_setup/git_setup.yaml` with 4 phases (init, remote, push, hooks)
+2. Create `workflows/git_setup/git_setup_helper/` role files
+3. Test standalone (`/git-setup`) and welcome-screen-activated paths
+
+**Delivers:** Git remote setup as a guided workflow, accessible from welcome screen.
+
+### Phase D: `codebase-setup` Facet Workflow
+
+1. Create `workflows/codebase_setup/codebase_setup.yaml` with 4 phases (locate, integrate, environment, verify)
+2. Create `workflows/codebase_setup/codebase_setup_helper/` role files
+3. Test standalone (`/codebase-setup`) and welcome-screen-activated paths
+
+**Delivers:** Codebase integration as an interactive guided workflow. Replaces the non-interactive Copier `_task`.

--- a/.project_team/bootstrapping_bridge/userprompt.md
+++ b/.project_team/bootstrapping_bridge/userprompt.md
@@ -1,0 +1,9 @@
+# User Prompt
+
+Design the bootstrapping bridge for AI_PROJECT_TEMPLATE.
+
+The template has a two-phase onboarding: Copier (generation time) and Claude/workflows (runtime). Information gathered in phase one doesn't reliably flow into phase two.
+
+Specific concern raised: PR #18 converts cluster_setup to an executable workflow, but there's no connection between what Copier already asked (ssh_target, scheduler) and what the workflow re-detects. Same pattern exists for git setup, codebase integration, and other setup concerns.
+
+Solve this generically — not just for cluster, but for all seams between template generation and runtime workflows.

--- a/.project_team/claudechic_ui_upgrade/SPEC.md
+++ b/.project_team/claudechic_ui_upgrade/SPEC.md
@@ -1,0 +1,824 @@
+# SPEC: claudechic UI Upgrade
+
+## Implementation Order
+
+| # | Item | Type | Est. Hours |
+|---|------|------|------------|
+| 1 | Issue #9 -- Workflow/phase display on restore | Bug fix | 1-2h |
+| 2 | ChicsessionActions buttons + WorkflowPickerScreen | New feature | 4-6h |
+| 3 | Issue #4 -- Agent sidebar overflow | Bug fix | 2-3h |
+| 4 | ComputerInfoLabel + ComputerInfoModal | New feature | 3-4h |
+| 5 | DiffButton + MarkdownPreview | New feature | 3-4h |
+| 6 | Agent Switcher (Ctrl+G style) | Enhancement | 4-6h |
+
+Items 1 and 3 are independent and can be parallelized.
+Item 2 depends on Item 1 (needs workflow state wired correctly first).
+Items 4 and 5 are independent of each other and of 1-3.
+
+---
+
+## Command Reality (verified)
+
+| What user types | What it does |
+|-----------------|-------------|
+| `/<workflow-id>` (e.g. `/project_team`) | Activates a workflow |
+| `/<workflow-id> stop` | Deactivates a workflow |
+| `/workflow list` | Lists discovered workflows |
+| `/workflow reload` | Rediscovers workflow manifests |
+| `/chicsession save <name>` | First-time save (after this, auto-save kicks in) |
+| `/chicsession restore` | Opens session picker |
+| `/chicsession restore <name>` | Restores named session directly |
+| `/diff` | Opens DiffScreen for uncommitted changes |
+
+There is NO `/advance` command. Phase advancement is agent-driven via MCP tools.
+Chicsession auto-saves on agent lifecycle events after initial manual save.
+
+---
+
+## Naming Conventions (from Terminology)
+
+| Element | Class Name | ID |
+|---------|------------|-----|
+| Footer computer info button | `ComputerInfoLabel` | `#computer-info-label` |
+| Computer info modal | `ComputerInfoModal` | -- |
+| Info modal base class | `InfoModal` | -- |
+| Sidebar action buttons container | `ChicsessionActions` | `#chicsession-actions` |
+| Action button widget | `ActionButton` | `#workflows-btn`, `#restore-btn`, `#stop-btn` |
+| Workflow picker screen | `WorkflowPickerScreen` | -- |
+| Workflow picker item | `WorkflowItem` | -- |
+| Files section diff trigger | `DiffButton` | `#diff-btn` |
+| Markdown preview modal | `MarkdownPreviewModal` | -- |
+| Agent switcher overlay | `AgentSwitcher` | `#agent-switcher` |
+| Footer agent name button | `AgentLabel` | `#agent-label` |
+
+Rules:
+- Footer clickables -> `XxxLabel` (extends `ClickableLabel`)
+- Sidebar containers -> `XxxSection` (extends `SidebarSection`)
+- Modal overlays -> `XxxModal` (extends `ModalScreen` or `InfoModal`)
+- Full-page pickers -> `XxxScreen` (extends `Screen`)
+- IDs use kebab-case
+- "Chicsession" is always one word, lowercase
+
+---
+
+## Item 1: Issue #9 -- Workflow/Phase Display on Restore
+
+**Problem:** `_handle_restore()` calls `_update_sidebar_label(app, name)` with only the name. It then calls `_restore_workflow_from_session()` which restores the engine but never updates the sidebar label.
+
+**Fix:** After `_restore_workflow_from_session()` in `chicsession_cmd.py` (~line 270), call `app._update_sidebar_workflow_info()` which already exists (app.py ~line 1749) and does the right thing.
+
+**Edge cases:**
+- No `workflow_state` in saved session -> leave workflow/phase empty (correct)
+- `workflow_state` exists but phase is None -> show workflow, hide phase
+- Stale workflow pointing to deleted workflow -> show name, log warning, don't crash
+
+**Files:** `claudechic/features/chicsession/chicsession_cmd.py`, `claudechic/app.py`
+
+---
+
+## Item 2: ChicsessionActions Buttons + WorkflowPickerScreen
+
+### 2A: ChicsessionActions
+
+**Widget hierarchy:**
+```
+ChicsessionLabel #chicsession-label
+  +-- Static .chicsession-title     ("Chicsession")
+  +-- Static .chicsession-value     (session name or "none")
+  +-- Static .chicsession-workflow  (workflow name)
+  +-- Static .chicsession-phase     (phase name)
+  +-- ChicsessionActions #chicsession-actions        <- NEW
+        +-- ActionButton #workflows-btn or #stop-btn
+        +-- ActionButton #restore-btn (idle only)
+```
+
+**Adaptive state machine:**
+
+| Workflow State | Buttons | Action on Click |
+|----------------|---------|-----------------|
+| No workflow active | `[Workflows]` `[Restore]` | Opens WorkflowPickerScreen / Opens ChicsessionScreen |
+| Workflow active | `[Stop]` | Triggers `/<active-wf-id> stop` |
+
+**ActionButton design:**
+- Extends `Static`, `can_focus = False` (CRITICAL: don't steal focus)
+- Each button type posts its own Message:
+  - `[Workflows]` -> `ChicsessionActions.WorkflowPickerRequested()`
+  - `[Restore]` -> `ChicsessionActions.RestoreRequested()`
+  - `[Stop]` -> `ChicsessionActions.StopRequested()`
+- ChatApp handles each message separately (no generic command dispatch)
+
+**State updates:** `ChicsessionActions.update_state(workflow_active: bool)` rebuilds buttons. Called by ChatApp on workflow activation, deactivation, and session restore.
+
+**Layout mockups:**
+
+No workflow:
+```
+Chicsession
+  none
+  [Workflows] [Restore]
+```
+
+Workflow active:
+```
+Chicsession
+  my-session
+  Workflow: project-team
+  Phase: leadership
+  [Stop]
+```
+
+**CSS:**
+```css
+ChicsessionActions { layout: horizontal; height: auto; padding: 0 1; }
+ActionButton { height: 1; padding: 0 1; background: $panel; color: $text-muted; }
+ActionButton:hover { background: $accent; color: white; }
+```
+
+**First-run hint** (direct `app.notify()` with `HintStateStore` persistence):
+
+Trigger: On first mount of `ChicsessionLabel` when no chicsession is loaded
+(`self._chicsession_name is None`) and sidebar is visible. This is the moment
+a new user sees the empty "none" state and would benefit from guidance.
+
+```python
+# In ChatApp, after sidebar becomes visible and chicsession label is mounted:
+if self._chicsession_name is None:
+    store = HintStateStore(self._cwd)
+    if store.get_times_shown("workflow-actions-tip") == 0:
+        self.notify(
+            "Tip: Click [Workflows] in the sidebar to start, or type /<workflow-name>",
+            severity="information",
+            timeout=8,
+        )
+        store.increment_shown("workflow-actions-tip")
+        store.save()
+```
+
+Does NOT use `global/hints.yaml` — the hints YAML pipeline is project-state
+based, not UI-event driven. Uses direct notify + `HintStateStore` for
+cross-session persistence (shows once ever, not once per session).
+Follows the precedent set by the existing Ctrl+N hint.
+
+### 2B: WorkflowPickerScreen
+
+**New file:** `claudechic/screens/workflow_picker.py`
+
+**Widget hierarchy:**
+```
+WorkflowPickerScreen (extends Screen[str | None])
+  +-- Vertical #workflow-picker-container
+        +-- Static #workflow-picker-title  ("Select Workflow (N available)")
+        +-- Input #workflow-search         ("Search workflows...")
+        +-- ListView #workflow-list
+              +-- WorkflowItem per workflow
+                    +-- Label .workflow-name  (workflow_id)
+                    +-- Label .workflow-meta  (role, phase count, status)
+```
+
+**Mockup:**
+```
+Select Workflow (4 available)
++------------------------------------------------------+
+| Search workflows...                                  |
++------------------------------------------------------+
+
+| project-team
+| role: coordinator . 5 phases . available
+
+| tutorial
+| role: learner . 4 phases . available
+
+| audit
+| role: auditor . 3 phases . available
+```
+
+**Data sources:**
+- workflow_id: key from `app._workflow_registry`
+- main_role: from `app._load_result.workflows[wf_id].main_role`
+- phase_count: count phases matching namespace
+- is_active: `wf_id == app._workflow_engine.workflow_id`
+
+**Interaction flow:**
+1. User clicks [Workflows] -> ChatApp pushes WorkflowPickerScreen
+2. User searches/navigates, selects a workflow
+3. Screen dismisses with `workflow_id` string
+4. ChatApp callback calls `_activate_workflow(workflow_id)` which handles chicsession naming etc.
+5. If selected workflow is already active -> toast "Already active", dismiss with None
+6. If different workflow is active -> toast "Stop current workflow first", dismiss with None
+
+**Edge cases:**
+- No workflows discovered -> empty state: "No workflows discovered. Add YAML files to workflows/"
+- Search returns nothing -> clear list, show "0 matches"
+- Already active workflow selected -> toast, no action
+- Different workflow active -> toast with stop instructions, no action (don't auto-stop)
+
+**Navigation:** Follows ChicsessionScreen pattern exactly (Up/Down arrows, Enter, Escape, real-time search filtering).
+
+**Files:** `claudechic/screens/workflow_picker.py` (new), `claudechic/widgets/layout/sidebar.py`, `claudechic/app.py`, `claudechic/styles.tcss`
+
+---
+
+## Item 3: Issue #4 -- Agent Sidebar Overflow
+
+**Two changes:**
+
+A. **Lower compact threshold:** If `agent_count > 6`, force compact mode regardless of available space.
+
+B. **Add scrolling:** Wrap AgentSection items in `VerticalScroll#agent-scroll`. Set `max_height` dynamically from `_layout_sidebar_contents()`.
+
+**Height budget change:** Add ChicsessionLabel to `_layout_sidebar_contents()` as a fixed cost:
+```
+CHICSESSION_BASE = 3        (title + name + action buttons)
+CHICSESSION_WORKFLOW = 2    (workflow + phase lines when active)
+```
+
+**Auto-scroll:** Active agent must scroll into view when switched.
+
+**Mockup (11 agents, compact, scrollable):**
+```
+Agents (11)              ^
+  o agent-1              |
+  * agent-2              =
+  * agent-3              |
+  o agent-4              v
+  o agent-5
+  * agent-6
+```
+
+**CSS:**
+```css
+AgentSection #agent-scroll { height: auto; scrollbar-size: 1; }
+```
+
+**Edge cases:**
+- 0 agents: section hidden (existing)
+- Agent added while scrolled: mount and auto-scroll if active
+- Agent removed: scroll adjusts naturally
+
+**Files:** `claudechic/widgets/layout/sidebar.py`, `claudechic/app.py` (`_layout_sidebar_contents`), `claudechic/styles.tcss`
+
+---
+
+## Item 4: ComputerInfoLabel + ComputerInfoModal
+
+**InfoModal base class** (new file: `claudechic/widgets/modals/base.py`):
+- `InfoSection` frozen dataclass: `title`, `content`, `copyable=True`, `scrollable=False`
+- `InfoModal(ModalScreen)`: takes `title: str` and `sections: list[InfoSection]`
+- Renders: header + sections (each with optional copy button) + close footer
+- ESC dismisses, copy buttons use pyperclip, close button dismisses
+- Refactor `DiagnosticsModal` to subclass `InfoModal`
+
+**ComputerInfoLabel** in footer:
+- Displays "sys" (3 chars) -- placed after DiagnosticsLabel with a separator
+- On click posts `ComputerInfoLabel.Requested()` message
+- ChatApp gathers data synchronously, constructs `ComputerInfoModal`
+
+**ComputerInfoModal sections:**
+
+| Field | Source |
+|-------|--------|
+| Host | `platform.node()` |
+| OS | `f"{platform.system()} {platform.release()} ({platform.machine()}")` |
+| Python | `platform.python_version()` |
+| SDK | `importlib.metadata.version("claude-code-sdk")` or `"unknown"` |
+| claudechic | `importlib.metadata.version("claudechic")` or `"unknown"` |
+| CWD | `self._cwd` |
+
+**Footer mockup:**
+```
+opus . Auto-edit: off . session_info . sys          [====30%====] CPU 12% branch develop
+```
+
+**Modal mockup:**
+```
++----------------------------------------------+
+| System Info                                  |
+|                                              |
+|  Host:        MacBook-Pro.local              |
+|  OS:          macOS 15.2 (arm64)             |
+|  Python:      3.12.4                         |
+|  SDK:         0.3.1                          |
+|  claudechic:  0.9.0                          |
+|  CWD:         /Users/me/project              |
+|                                              |
+|             [Copy]  [Close]                  |
++----------------------------------------------+
+```
+
+**CSS:** Modal centered, 40-60 cols wide, surface background, bordered, info rows at height 1.
+
+**Files:** `claudechic/widgets/modals/base.py` (new), `claudechic/widgets/modals/diagnostics.py` (refactor), `claudechic/widgets/layout/footer.py`, `claudechic/app.py`, `claudechic/styles.tcss`
+
+---
+
+## Item 5: DiffButton + MarkdownPreview
+
+### 5A: DiffButton in FilesSection Header
+
+**SidebarSection modification:** Accept optional `header_actions` parameter. When provided, compose title in a `Horizontal` with action widgets alongside.
+
+**DiffButton:** Extends `Static`, `can_focus = False`, renders "/diff", posts `DiffButton.DiffRequested()`. ChatApp handles via `self._handle_prompt("/diff")`.
+
+**FilesSection header mockup:**
+```
+Files                /diff
+  ...sidebar.py      +12 -3
+```
+
+**Files:** `claudechic/widgets/layout/sidebar.py`
+
+### 5B: Markdown Preview Toggle in DiffScreen
+
+The user wants to see spec files (.md) as rendered markdown when reviewing diffs.
+This is NOT a standalone modal — it's wired INTO the existing DiffScreen diff viewer.
+
+**Architecture:** Each `FileDiffPanel` for a `.md` file gets a `[Preview]` toggle
+button in its `FileHeaderLabel` row. Clicking it swaps the hunk widgets for a
+rendered `Markdown` widget showing the file's current content.
+
+**Widget hierarchy change in FileDiffPanel (for .md files only):**
+```
+FileDiffPanel
+  +-- Horizontal .file-header-row               <- NEW wrapper
+  |     +-- FileHeaderLabel (existing)
+  |     +-- PreviewToggle #preview-{safe_id}     <- NEW (only for .md files)
+  +-- HunkWidget ...                             <- visible when preview OFF
+  +-- HunkSeparator ...                          <- visible when preview OFF
+  +-- VerticalScroll #md-preview-{safe_id}       <- visible when preview ON
+        +-- Markdown #md-content-{safe_id}         (Textual built-in)
+```
+
+**PreviewToggle widget:**
+```python
+class PreviewToggle(Static):
+    """Toggle button: switches between diff hunks and rendered markdown."""
+    can_focus = False
+
+    class Toggled(Message):
+        def __init__(self, path: str, show_preview: bool) -> None:
+            self.path = path
+            self.show_preview = show_preview
+            super().__init__()
+
+    def __init__(self, path: str, **kwargs) -> None:
+        super().__init__("[Preview]", **kwargs)
+        self._path = path
+        self._preview_active = False
+
+    def on_click(self, event) -> None:
+        event.stop()
+        self._preview_active = not self._preview_active
+        label = "[Diff]" if self._preview_active else "[Preview]"
+        self.update(label)
+        self.post_message(self.Toggled(self._path, self._preview_active))
+```
+
+**FileDiffPanel changes:**
+- In `compose()`, detect if `self.change.path.endswith(".md")`.
+- If .md: wrap header in `Horizontal`, add `PreviewToggle`, and mount a hidden
+  `VerticalScroll` with `Markdown` widget after the hunks.
+- Handle `PreviewToggle.Toggled`: toggle visibility of hunks vs markdown container.
+- Markdown content loaded lazily on first toggle (read file from disk via `Path.read_text(encoding='utf-8')`).
+
+**DiffSidebar enhancement:** `.md` files get a small "md" badge in their `DiffFileItem`:
+```
+M  ...SPEC.md (2)  md  ✎
+```
+
+**Mockup — DiffScreen with .md file, diff mode (default):**
+```
++-------------------------------+--------------------------------------------+
+| Changed Files                 |  .project_team/.../SPEC.md      [Preview]  |
+|                               |                                            |
+|   M ...SPEC.md (2)  md  e    |  @@ -250,8 +250,6 @@                       |
+|   M ...footer.py (3)    e    |  - | MCP | Count from self._mcp_server |   |
+|   M ...sidebar.py (1)   e    |  - | Agents | len(self.agent_mgr) |        |
+|                               |                                            |
+|                               |  @@ -273,10 +271,8 @@                     |
+|                               |  -|  MCP:         1 server (chic)  |       |
+|                               |  -|  Agents:      3 active         |       |
++-------------------------------+--------------------------------------------+
+```
+
+**Mockup — DiffScreen with .md file, preview mode (after clicking [Preview]):**
+```
++-------------------------------+--------------------------------------------+
+| Changed Files                 |  .project_team/.../SPEC.md         [Diff]  |
+|                               |                                            |
+|   M ...SPEC.md (2)  md  e    |  # SPEC: claudechic UI Upgrade             |
+|   M ...footer.py (3)    e    |                                            |
+|   M ...sidebar.py (1)   e    |  ## Implementation Order                   |
+|                               |                                            |
+|                               |  | # | Item        | Type    | Est. Hours ||
+|                               |  |---|-------------|---------|------------|
+|                               |  | 1 | Issue #9... | Bug fix | 1-2h      ||
+|                               |  ...                                       |
++-------------------------------+--------------------------------------------+
+```
+
+**Interaction flow:**
+1. User opens DiffScreen (via /diff or sidebar [/diff] button).
+2. For .md files, `[Preview]` button appears in the file header row.
+3. Click `[Preview]` -> hunks hide, rendered markdown appears, button label changes to `[Diff]`.
+4. Click `[Diff]` -> markdown hides, hunks reappear, button label changes to `[Preview]`.
+5. Navigation (j/k) skips over the file when in preview mode (hunks are hidden, not focusable).
+6. Comments on hunks are preserved across toggles (HunkWidgets stay mounted, just hidden).
+
+**Data source for preview content:**
+- `Path(cwd / change.path).read_text(encoding='utf-8')` — reads CURRENT file content (post-edit).
+- Loaded lazily on first `[Preview]` click, cached in `FileDiffPanel._md_content`.
+- 50KB size gate: if file > 50KB, toast "File too large for preview" and don't toggle.
+
+**CSS:**
+```css
+PreviewToggle { width: auto; height: 1; padding: 0 1; color: $text-muted; pointer: pointer; }
+PreviewToggle:hover { color: $primary; background: $panel; }
+FileDiffPanel .md-preview { height: auto; min-height: 10; padding: 0 1; }
+FileDiffPanel .md-preview.hidden { display: none; }
+```
+
+**Edge cases:**
+- File deleted between diff and preview click -> toast "File not found", stay in diff mode.
+- UnicodeDecodeError -> toast "Cannot preview file", stay in diff mode.
+- Empty .md file -> show "(empty file)" placeholder in preview area.
+- Non-.md files -> no PreviewToggle, no change to existing behavior.
+- Binary files -> no PreviewToggle (already handled as "no diff available").
+- Hunk navigation: when preview is active for a file, j/k skip to next file's hunks.
+- Comments: toggling to preview and back preserves all hunk comments (widgets stay mounted, just display:none).
+
+**Also keep MarkdownPreviewModal for sidebar .md clicks:**
+The standalone `MarkdownPreviewModal` is ALSO still useful for clicking `.md` files
+in the chat sidebar (FilesSection) when NOT in DiffScreen. Keep it as a simpler
+read-only viewer for that context.
+
+**New file:** `claudechic/widgets/content/markdown_preview.py`
+- `MarkdownPreviewModal(ModalScreen)` — for sidebar FileItem clicks on .md files
+- `PreviewToggle(Static)` — for DiffScreen integration
+
+**Files:** `claudechic/widgets/content/markdown_preview.py` (new), `claudechic/features/diff/widgets.py` (modify FileDiffPanel, FileHeaderLabel, DiffFileItem), `claudechic/app.py`, `claudechic/styles.tcss`
+
+---
+
+## Item 6: Agent Switcher (Ctrl+G style)
+
+**Rationale:** Addresses the discoverability fallback concern -- sidebar buttons only show at >= 110 terminal width. The agent switcher works at ANY terminal size via keyboard.
+
+### 6A: AgentSwitcher Modal
+
+**Widget hierarchy:**
+```
+AgentSwitcher(ModalScreen)
+  +-- Vertical #agent-switcher-container
+        +-- Input #agent-search (placeholder: "search agents...")
+        +-- ListView #agent-results
+              +-- AgentSwitcherItem (per agent, shows name + status)
+```
+
+**Mockup:**
+```
++-----------------------------------+
+| > search agents...                |
+|                                   |
+|   * Coordinator        (busy)     |
+| > o UIDesigner          (idle)    |
+|   * Implementer        (busy)     |
++-----------------------------------+
+```
+
+**Keybinding:** Ctrl+G (avoids conflict with Ctrl+A select-all, Ctrl+P print).
+- Fuzzy search by agent name
+- Up/Down to navigate, Enter to switch, Escape to dismiss
+- Shows status indicators (same as sidebar)
+
+### 6B: AgentLabel in Footer
+
+**Naming:** `AgentLabel` (extends `ClickableLabel`), ID `#agent-label`.
+
+**What it displays:** The active agent's display name, truncated to 12 chars max.
+- Single agent (default "main"): hidden (no label shown — avoids clutter for solo users).
+- Multiple agents: shows active agent name, e.g. "Coordinator".
+- No agents connected: hidden.
+
+This is more useful than a generic "agents" label because it tells the user
+WHICH agent they're talking to — critical context when running multi-agent sessions.
+
+**Footer position:** Right side, between ProcessIndicator and ContextBar. This groups
+it with other status indicators rather than the left-side settings cluster.
+
+**Updated footer compose order:**
+```
+Horizontal #footer-content
+  +-- ViModeLabel
+  +-- ModelLabel
+  +-- Static (sep)
+  +-- PermissionModeLabel
+  +-- Static (sep)
+  +-- DiagnosticsLabel
+  +-- Static (sep)
+  +-- ComputerInfoLabel "sys"
+  +-- Static #footer-spacer (1fr)
+  +-- ProcessIndicator
+  +-- AgentLabel #agent-label             <- NEW (hidden when single agent)
+  +-- ContextBar
+  +-- CPUBar
+  +-- Static #branch-label
+```
+
+**Footer mockup — single agent (label hidden):**
+```
+ opus . Auto-edit: off . session_info . sys          [====30%====] CPU 12% develop
+```
+
+**Footer mockup — multiple agents, "Coordinator" active:**
+```
+ opus . Auto-edit: off . session_info . sys       Coordinator [==30%==] CPU 12% develop
+```
+
+**Footer mockup — 80-col terminal, multiple agents:**
+```
+ opus . Auto-edit: off . session_info . sys  Coordin.. [30%] CPU 12% develop
+```
+(Truncated to fit — the `1fr` spacer compresses, and the label truncates at 12 chars max.)
+
+**Interaction:**
+1. Click `AgentLabel` -> posts `AgentLabel.SwitcherRequested()` message.
+2. ChatApp handles by pushing `AgentSwitcher` modal (same as Ctrl+G).
+3. `can_focus = False` — does not steal focus from chat input.
+
+**Reactive updates:** ChatApp calls `agent_label.update_agent(name, visible)` when:
+- Agent is switched (`on_agent_switched`)
+- Agent is created/closed (agent count changes)
+- Set `visible=False` when `len(self.agent_mgr) <= 1`
+
+**Widget design:**
+```python
+class AgentLabel(ClickableLabel):
+    """Shows active agent name. Click to open Agent Switcher."""
+
+    class SwitcherRequested(Message):
+        """Emitted when user clicks to open agent switcher."""
+
+    MAX_NAME_LEN = 12
+
+    def on_click(self, event) -> None:
+        self.post_message(self.SwitcherRequested())
+
+    def update_agent(self, name: str, visible: bool) -> None:
+        """Update displayed agent name and visibility."""
+        if not visible:
+            self.add_class("hidden")
+            return
+        self.remove_class("hidden")
+        display = name[:self.MAX_NAME_LEN - 2] + ".." if len(name) > self.MAX_NAME_LEN else name
+        self.update(display)
+```
+
+**CSS:**
+```css
+AgentLabel { width: auto; padding: 0 1; color: $text-muted; }
+AgentLabel:hover { background: $panel; }
+AgentLabel.hidden { display: none; }
+```
+
+### 6C: Discovery Hint
+
+Uses direct `app.notify()` with `HintStateStore` for cross-session persistence.
+Does NOT use `global/hints.yaml` — the hints YAML pipeline is project-state
+based, not UI-event driven. Follows the precedent set by the existing Ctrl+N hint.
+
+**When to show:** On the first time a second agent is created (agent count goes
+from 1 to 2). This is the moment the feature becomes relevant. Showing at
+startup would be noise for single-agent users.
+
+**Trigger point:** In ChatApp's `on_agent_created()` handler:
+```python
+if len(self.agent_mgr.agents) == 2:
+    store = HintStateStore(self._cwd)
+    if store.get_times_shown("agent-switcher-tip") == 0:
+        self.notify(
+            "Tip: Press Ctrl+G to switch agents, or click the agent name in the bottom bar",
+            severity="information",
+            timeout=8,
+        )
+        store.increment_shown("agent-switcher-tip")
+        store.save()
+```
+
+**Persistence:** `HintStateStore` writes to `.chicsessions/.hint_state.json`
+(or equivalent project-local path). The `get_times_shown` / `increment_shown`
+API ensures the hint shows once ever across all sessions, not once per session.
+
+**Files:** `claudechic/widgets/modals/agent_switcher.py` (new), `claudechic/widgets/layout/footer.py` (add AgentLabel), `claudechic/app.py` (handlers, hint trigger), `claudechic/styles.tcss`
+
+---
+
+## New Files Summary
+
+| File | Contents |
+|------|----------|
+| `claudechic/widgets/modals/base.py` | `InfoSection`, `InfoModal` base class |
+| `claudechic/screens/workflow_picker.py` | `WorkflowPickerScreen`, `WorkflowItem` |
+| `claudechic/widgets/content/markdown_preview.py` | `MarkdownPreviewModal` |
+| `claudechic/widgets/modals/agent_switcher.py` | `AgentSwitcher`, `AgentSwitcherItem` |
+
+## Modified Files Summary
+
+| File | Changes |
+|------|---------|
+| `claudechic/features/chicsession/chicsession_cmd.py` | Item 1: add workflow info update after restore |
+| `claudechic/widgets/layout/sidebar.py` | Items 2,3,5A: ChicsessionActions, ActionButton, AgentSection scroll, SidebarSection header_actions, DiffButton |
+| `claudechic/widgets/layout/footer.py` | Item 4: add ComputerInfoLabel |
+| `claudechic/widgets/modals/diagnostics.py` | Item 4: refactor to extend InfoModal |
+| `claudechic/features/diff/widgets.py` | Item 5B: PreviewToggle in FileDiffPanel, md badge in DiffFileItem |
+| `claudechic/app.py` | Items 1-6: message handlers, height budget, workflow picker callback |
+| `claudechic/styles.tcss` | Items 2-6: new styles |
+| `claudechic/screens/chat.py` | Item 2: mount ChicsessionActions |
+
+---
+
+## TDD Test Plan
+
+9 tests (7 main + 2 edge cases). Tests are written BEFORE implementation.
+
+### Testing Patterns
+
+| Pattern | When to use | Mocking |
+|---------|-------------|---------|
+| **WidgetTestApp** | Isolated widget behavior | ZERO mocking. Mount widget in minimal Textual app. |
+| **ChatApp + mock_sdk** | Full app integration flows | Uses existing `mock_sdk` fixture from conftest.py. |
+
+### Approved Mocks (beyond mock_sdk)
+
+Only 2 additional mocks were approved:
+1. `app._workflow_registry` dict injection (Test 4 — workflow picker integration)
+2. `FileChange` list injection (Tests 7-8 — diff preview)
+
+### Tests
+
+**Test 1: `test_restore_session_shows_workflow_and_phase`** (Item 1)
+- Pattern: ChatApp + mock_sdk
+- Setup: Write `.chicsessions/test.json` in tmp_path with `workflow_state: {"workflow_id": "tutorial", "current_phase": "tutorial:design"}`
+- Action: Mount ChatApp at size=(120,40), submit `/chicsession restore test`
+- Assert:
+  - `chicsession_label.workflow_text == "tutorial"`
+  - `chicsession_label.phase_text == "design"`
+  - Both Static widgets have `display != none`
+
+**Test 2: `test_restore_with_missing_workflow_state`** (Item 1 edge case)
+- Pattern: ChatApp + mock_sdk
+- Setup: Write `.chicsessions/test.json` WITHOUT `workflow_state` key
+- Action: Mount ChatApp, submit `/chicsession restore test`
+- Assert:
+  - `chicsession_label.workflow_text == ""`
+  - `chicsession_label.phase_text == ""`
+  - No crash, no exception
+
+**Test 3: `test_chicsession_buttons_adapt_to_workflow_state`** (Item 2)
+- Pattern: WidgetTestApp (ZERO mocking)
+- Setup: Mount ChicsessionLabel at size=(120,40)
+- Action 1: Check initial state (no workflow)
+- Assert 1:
+  - `#workflows-btn` is present and visible
+  - `#restore-btn` is present and visible
+  - `#stop-btn` is NOT present
+  - Click `#restore-btn` -> assert `ChicsessionActions.RestoreRequested` message is posted (U1)
+- Action 2: Set `chicsession_label.workflow_text = "project-team"` (triggers state update)
+- Assert 2:
+  - `#stop-btn` is present and visible
+  - `#workflows-btn` is NOT present
+  - `#restore-btn` is NOT present
+  - Click `#stop-btn` -> assert `ChicsessionActions.StopRequested` message is posted (U3)
+- Action 3: Resize to 80x24 (narrow terminal, below SIDEBAR_MIN_WIDTH=110)
+- Assert 3:
+  - ChicsessionActions buttons are not visible (sidebar hidden at < 110 width) (U2)
+  - Verifies graceful degradation for narrow terminals
+
+**Test 4: `test_workflows_button_opens_picker_and_activates`** (Item 2)
+- Pattern: ChatApp + mock_sdk
+- Setup: Inject `app._workflow_registry = {"tutorial": Path("/tmp/workflows/tutorial")}` after mount. Pre-set `app._chicsession_name = "test"` to prevent `_activate_workflow` from prompting for a session name (C1). Size=(120,40).
+- Action: Click `#workflows-btn`, wait for WorkflowPickerScreen, select "tutorial" item, press Enter
+- Assert:
+  - WorkflowPickerScreen was pushed (check screen stack)
+  - Screen lists "tutorial" as a WorkflowItem
+  - After selection and dismiss, `chicsession_label.workflow_text == "tutorial"`
+- Height budget integration (C2):
+  - Action: After picker flow completes, add 8 agents via `agent_section.add_agent()`
+  - Assert: ChicsessionActions buttons/labels still visible (no `display: none`)
+  - Assert: All AgentSection items are queryable and visible (no `display: none`)
+  - Verifies height budget coordination between Items 2 and 3
+- Approved mock: `app._workflow_registry` dict injection
+
+**Test 5: `test_sidebar_handles_many_agents`** (Item 3)
+- Pattern: WidgetTestApp (ZERO mocking)
+- Setup: Mount AgentSection
+- Action: Call `agent_section.add_agent(f"id-{i}", f"Agent-{i}")` for 12 agents
+- Assert:
+  - All AgentItems have the `compact` CSS class: `all(item.has_class("compact") for item in agent_section.query(AgentItem))` (S1: tests observable output, not private state)
+  - `VerticalScroll` container exists as child (query `#agent-scroll`)
+  - All 12 AgentItem widgets are queryable (`len(agent_section.query(AgentItem)) == 12`)
+  - No items have `display: none`
+
+**Test 6: `test_sys_label_click_opens_modal`** (Item 4)
+- Pattern: WidgetTestApp with StatusFooter
+- Setup: Mount StatusFooter
+- Action: Click `#computer-info-label`
+- Assert:
+  - `ComputerInfoModal` is pushed onto screen stack
+  - Modal contains Static widgets with non-empty text for: Host, OS, Python, CWD
+  - SDK and claudechic values are either valid version strings or "unknown"
+  - Pressing Escape dismisses the modal (screen stack returns to previous)
+
+**Test 7: `test_diff_button_and_md_preview_toggle`** (Item 5)
+- Pattern: WidgetTestApp for Part A; DiffScreen with injected FileChange for Part B
+- Part A -- DiffButton:
+  - Setup: Mount FilesSection with header_actions
+  - Action: Click DiffButton
+  - Assert: `DiffButton.DiffRequested` message is posted
+- Part B -- Preview toggle:
+  - Setup: Mount DiffScreen with FileChange list including one `.md` file change. Write a real `.md` file (< 50KB) to tmp_path.
+  - Action: Select the `.md` file, click `[Preview]` toggle
+  - Assert: Hunk widgets are hidden (`display: none`), Markdown widget is visible and contains rendered content
+  - Action: Click `[Diff]` toggle
+  - Assert: Hunk widgets visible again, Markdown widget hidden
+  - Assert: For non-.md files, no PreviewToggle widget exists
+- Approved mock: `FileChange` list injection for DiffScreen
+
+**Test 8: `test_md_preview_rejects_large_files`** (Item 5 edge case)
+- Pattern: Same as Test 7 Part B
+- Setup: Write a `.md` file > 50KB to tmp_path. Inject FileChange pointing to it.
+- Action: Select the .md file, click `[Preview]`
+- Assert:
+  - Toast notification appears with "too large" message
+  - Hunk widgets remain visible (preview did NOT activate)
+  - No Markdown widget mounted
+
+**Test 9: `test_agent_switcher_hint_and_ctrl_g`** (Item 6)
+- Pattern: ChatApp + mock_sdk
+- Setup: Mount ChatApp at size=(120,40). Starts with 1 agent (default main).
+- Step 1 -- Hint fires on 1->2:
+  - Action: Create second agent
+  - Assert: Toast notification fired with text containing "Ctrl+G"
+  - Assert: `HintStateStore(app._cwd).get_times_shown("agent-switcher-tip") == 1`
+  - Assert: `AgentLabel` in footer is visible, shows second agent's name (or main's name depending on which is active)
+- Step 2 -- Hint does NOT repeat on 2->3:
+  - Action: Create third agent
+  - Assert: NO new toast with "Ctrl+G" text
+  - Assert: `HintStateStore(app._cwd).get_times_shown("agent-switcher-tip") == 1` (unchanged)
+- Step 3 -- Ctrl+G opens switcher:
+  - Action: Press Ctrl+G
+  - Assert: `AgentSwitcher` modal is on screen stack, lists 3 agents with names
+- Step 4 -- Navigate and switch:
+  - Action: Press Down arrow, press Enter (select second agent)
+  - Assert: Modal dismissed
+  - Assert: Active agent changed to the second agent
+  - Assert: `AgentLabel` text updated to second agent's name
+- Step 5 -- AgentLabel hides at 1 agent:
+  - Action: Close 2 agents (back to 1)
+  - Assert: `AgentLabel` is hidden
+- Step 6 -- Cross-session persistence:
+  - Action: Tear down the ChatApp instance
+  - Action: Create a NEW ChatApp instance pointing at the SAME tmp_path (same `_cwd`, so same HintStateStore on disk)
+  - Action: Mount at size=(120,40), create 2 agents (reach the 1->2 threshold again)
+  - Assert: NO toast notification fires (HintStateStore already has times_shown == 1 from previous app session)
+  - Assert: `HintStateStore(app._cwd).get_times_shown("agent-switcher-tip") == 1` (unchanged)
+  - This verifies the hint fires once EVER, not once per app session
+- No new mocks: HintStateStore uses `app._cwd` which points at tmp_path in test
+
+### Test Summary
+
+| Test | Item | Pattern | Mocks |
+|------|------|---------|-------|
+| 1 | Item 1 (restore wf display) | ChatApp + mock_sdk | mock_sdk only |
+| 2 | Item 1 (missing wf state) | ChatApp + mock_sdk | mock_sdk only |
+| 3 | Item 2 (button adaptation) | WidgetTestApp | NONE |
+| 4 | Item 2 (picker flow) | ChatApp + mock_sdk | mock_sdk + registry injection |
+| 5 | Item 3 (agent overflow) | WidgetTestApp | NONE |
+| 6 | Item 4 (sys modal) | WidgetTestApp | NONE |
+| 7 | Item 5 (diff + preview) | WidgetTestApp + DiffScreen | FileChange injection |
+| 8 | Item 5 (large file gate) | DiffScreen | FileChange injection |
+| 9 | Item 6 (hint + switcher) | ChatApp + mock_sdk | mock_sdk only |
+
+---
+
+## Cross-Cutting Constraints
+
+1. **ASCII only** -- no new emoji/unicode beyond what exists (existing circle/branch symbols OK)
+2. **`encoding='utf-8'`** on ALL file I/O
+3. **`can_focus = False`** on all sidebar buttons and footer labels
+4. **Message-based seams only** -- widgets post Messages, ChatApp handles
+5. **pathlib.Path everywhere** -- no string concatenation with `/`
+6. **Test at 80x24, 110x40, 160x50** terminal sizes
+7. **Windows safe** -- use `platform` module not subprocess for system info, guard any process-related calls
+
+---
+
+## Risks and Mitigations (from Skeptic)
+
+| Risk | Mitigation |
+|------|------------|
+| Footer overflow at 80 cols | "sys" is only 3 chars + separator = 5 cols added |
+| Sidebar buttons invisible < 110 width | First-run hint toast + Agent Switcher (Item 6) |
+| Compact threshold change breaks layout | Add ChicsessionLabel to height budget, test at multiple sizes |
+| Markdown preview freezes on large files | 50KB size gate |
+| Click handlers steal focus | `can_focus = False` on all new clickable widgets |
+| Windows emoji rendering | ASCII only for new elements |

--- a/.project_team/claudechic_ui_upgrade/SPEC_APPENDIX.md
+++ b/.project_team/claudechic_ui_upgrade/SPEC_APPENDIX.md
@@ -1,0 +1,88 @@
+# SPEC APPENDIX: claudechic UI Upgrade
+
+## Architecture Decision Rationale
+
+### InfoModal Base Class
+DiagnosticsModal and ComputerInfoModal share 90% structure. Extracting a base class
+(`InfoModal`) with a frozen `InfoSection` dataclass keeps the seam clean: callers
+provide data, InfoModal handles presentation. Future info modals become trivial.
+
+DiagnosticsModal remains a subclass (it has data-resolution logic in __init__).
+ComputerInfoModal can be a thin subclass or factory function.
+
+### SidebarSection Header Actions
+Rather than special-casing DiffButton in FilesSection, the pattern is generalized:
+SidebarSection accepts optional `header_actions` list. Default is None, so existing
+sections are unaffected. This is reusable for any section wanting header buttons.
+
+### ChicsessionActions Descriptor Model
+Actions use generic `(command_string, label)` pairs rather than hardcoded buttons.
+This keeps ChicsessionLabel agnostic about what commands exist. New actions can be
+added without modifying the widget.
+
+### Message Seam Integrity
+All widgets communicate via Textual Messages bubbling up to ChatApp. No widget
+imports or calls methods on another widget. The one existing violation is
+`ContextBar.on_click()` calling `self.app._handle_prompt("/context")` -- new widgets
+should post Messages instead.
+
+## Rejected Alternatives
+
+### Merging DiagnosticsModal and ComputerInfoModal
+Rejected: they serve different purposes (session diagnostics vs system info).
+Merging would create a bloated modal.
+
+### Inline Markdown preview in sidebar
+Rejected: sidebar is 28 chars wide -- too narrow for readable Markdown.
+Modal at 80% width is the correct UX.
+
+### Adding computer_info as verbose text in footer
+Rejected: footer is already ~80 chars. Verbose text would overflow on narrow
+terminals. Short "sys" label + modal is the correct pattern.
+
+### Ctrl+A for Agent Switcher keybinding
+Rejected: conflicts with select-all in text input. Ctrl+G chosen instead.
+
+### Adding emoji indicators for new elements
+Rejected: CLAUDE.md mandates ASCII only for cross-platform safety.
+Windows conhost.exe does not render emoji correctly.
+
+## What NOT To Do
+
+1. Do NOT merge footer labels -- each is independent, don't combine session_info + sys.
+2. Do NOT use `os.uname()` -- not available on Windows. Use `platform` module.
+3. Do NOT make sidebar buttons focusable -- `can_focus = False` prevents stealing
+   focus from chat input.
+4. Do NOT hardcode button labels in ChicsessionActions -- use the descriptor model.
+5. Do NOT skip the 50KB size gate on MarkdownPreview -- large files will freeze the TUI.
+6. Do NOT add scrolling to AgentSection without also updating `_layout_sidebar_contents()`
+   height budget -- they must be coordinated.
+7. Do NOT use bare "Session" for chicsession context -- always prefix with "Chicsession".
+
+## Leadership Agent Reports Summary
+
+### Composability
+- 5 independent architectural axes identified (footer items, sidebar sections, modals,
+  interactivity level, data sources)
+- All items touch different zones -- no conflicts
+- Recommended InfoModal base class, SidebarActionButton pattern, SectionAction header pattern
+- Recommended order: 2 -> (1, 3, 5 parallel) -> 4 -> 6
+
+### Terminology
+- Naming conventions locked: XxxLabel (footer), XxxSection (sidebar), XxxModal (modals)
+- Key conflict avoidance: "Chicsession" always one word, never bare "Session"
+- DiffButton (not DiffLabel) -- it triggers navigation, not displays status
+
+### Skeptic
+- Footer already ~80 chars -- ComputerInfoLabel must be SHORT
+- Sidebar only shows at >= 110 width -- discoverability paradox for new users
+- Items 3 and 4 compete for sidebar vertical space
+- Windows cross-platform concerns: no os.uname, use platform module
+- Test at 80x24, 110x40, 160x50 terminal sizes
+
+### UserAlignment
+- Priority: bug fix (Item 2) first for trust, then discoverability (Item 4)
+- Empty-state gap: new users with no sessions need guidance, not blank labels
+- Action buttons should adapt based on workflow state
+- Non-sidebar fallback needed (hints + Agent Switcher)
+- Session Health dashboard and Agent Switcher proposed as enhancements

--- a/.project_team/claudechic_ui_upgrade/STATUS.md
+++ b/.project_team/claudechic_ui_upgrade/STATUS.md
@@ -1,0 +1,58 @@
+# claudechic_ui_upgrade — STATUS
+
+## Phase: Complete
+## Working Directory: /Users/moharb/Documents/Repos/AI_PROJECT_TEMPLATE
+## Target: submodules/claudechic/
+
+## Work Items
+
+| # | Item | Owner | Status |
+|---|------|-------|--------|
+| 1 | Bottom bar computer_info button | AI agent | DONE |
+| 2 | Issue #9 — restore workflow/phase display | AI agent | DONE |
+| 3 | Issue #4 — agent sidebar overflow | AI agent | DONE |
+| 4 | ChicsessionLabel action buttons | AI agent | DONE |
+| 5 | FilesSection /diff button + MD preview | AI agent | DONE |
+| 6 | Agent switcher + hints (team-sourced ideas) | AI agent | DONE |
+
+## Extra Work Completed
+
+| Item | Description |
+|------|-------------|
+| FilesSection visibility fix | `#agent-scroll` and `#files-scroll` had default Textual `height: 1fr`, causing AgentSection to fill the entire sidebar and push FilesSection off-screen (y=43 on a 40-line terminal). Fixed with `height: auto` on both scroll containers. |
+| Files header row | Title ("Files") and /diff button now share one `Horizontal` row instead of stacking vertically. `FILES_OVERHEAD` updated from 5 to 4 in `_layout_sidebar_contents`. |
+| chicsession_overhead fix | `_layout_sidebar_contents` used hardcoded `CHICSESSION_OVERHEAD = 3` but ChicsessionLabel is 5 lines when a workflow is active. Made dynamic: `3 + (2 if self._workflow_engine else 0)`. |
+| FilesSection VerticalScroll | Added `VerticalScroll(id="files-scroll")` to FilesSection so file items scroll rather than overflow. |
+| Rich bracket escaping | `\[Preview]` / `\[Diff]` labels in PreviewToggle use raw strings to prevent Rich from consuming `[Preview]` as an unknown markup tag (renders as empty string). |
+| get_file_stats cwd wiring | `_async_refresh_files` passes `agent.cwd` (= `Path.cwd()` at launch) to `get_file_stats`. Confirmed returns 6 files from parent repo. |
+
+## Key Files Modified
+
+- `claudechic/widgets/layout/sidebar.py` — FilesSection (VerticalScroll, header row, CSS), AgentSection (height:auto), FilesSection CSS visibility
+- `claudechic/app.py` — `_async_refresh_files`, `_position_right_sidebar`, `_layout_sidebar_contents` (dynamic chicsession_overhead, FILES_OVERHEAD=4)
+- `claudechic/widgets/content/markdown_preview.py` — PreviewToggle bracket escaping, MarkdownPreviewModal
+- `claudechic/screens/chat.py` — sidebar compose order (ChicsessionLabel, AgentSection, PlanSection, FilesSection, TodoPanel, ReviewPanel, ProcessPanel)
+- `tests/test_widgets.py` — three new FilesSection tests
+
+## Tests Added
+
+| Test | What it catches |
+|------|-----------------|
+| `test_files_section_scrolls_with_many_files` | FilesSection must contain `VerticalScroll#files-scroll`; 20 items all queryable |
+| `test_files_section_visible_with_workflow_active` | At H=29 with workflow active + 4 agents + 5 files, agents must compact (overhead=5 not 3) |
+| `test_files_section_renders_with_files` | FilesSection `y < 40` in sidebar-like layout — catches the `height:1fr` regression that pushed FilesSection off-screen |
+
+## Git State
+- Parent repo: develop branch, uncommitted changes
+- Submodule (claudechic): develop branch, uncommitted changes
+
+## Key Files (original)
+- Footer: `claudechic/widgets/layout/footer.py`
+- Sidebar: `claudechic/widgets/layout/sidebar.py`
+- Indicators: `claudechic/widgets/layout/indicators.py`
+- Chicsession screen: `claudechic/screens/chicsession.py`
+- Chicsession manager: `claudechic/chicsessions.py`
+- Diff system: `claudechic/features/diff/`, `claudechic/screens/diff.py`
+- Diagnostics modal: `claudechic/widgets/modals/diagnostics.py`
+- Styles: `claudechic/styles.tcss`
+- Main app: `claudechic/app.py`

--- a/.project_team/claudechic_ui_upgrade/userprompt.md
+++ b/.project_team/claudechic_ui_upgrade/userprompt.md
@@ -1,0 +1,15 @@
+# User Prompt — claudechic UI Upgrade
+
+Upgrade claudechic's look and usability:
+
+1. **Bottom bar `computer_info` button** — clickable label (like session_info) showing hostname, OS, SDK version. Opens a ComputerInfoModal. Team should suggest additional items.
+
+2. **Issue #9 — Session restore workflow/phase display** — ChicsessionLabel doesn't populate workflow_text/phase_text on load from .chicsessions/*.json. Data is in workflow_state, just needs wiring.
+
+3. **Issue #4 — Agent sidebar overflow** — Compact mode triggers too late with 11+ agents. Lower threshold and/or add scrolling.
+
+4. **ChicsessionLabel always-visible action buttons** — Add /workflow, /chicsession restore buttons so new users discover them without knowing slash commands. UIDesigner should propose layout.
+
+5. **FilesSection /diff button + Markdown preview** — Clickable /diff trigger in FilesSection header. Rendered Markdown display for .md files (spec files).
+
+6. **Team-sourced ideas** — Leadership agents propose additional enhancements.

--- a/.project_team/subagent_phase_injection/SPEC.md
+++ b/.project_team/subagent_phase_injection/SPEC.md
@@ -1,0 +1,449 @@
+# Architectural Specification: Sub-Agent Phase Injection (#37)
+
+**Author:** Composability (Lead Architect)
+**Phase:** Specification
+**Date:** 2026-04-15
+
+> **Terminology:** This spec uses the canonical terms from the Terminology
+> Report. See `terminology_report.md` for definitions. Key terms: **agent
+> prompt** (assembled identity file + phase file), **phase context**
+> (`.claude/phase_context.md`, coordinator only), **spawn prompt** (task
+> instructions from coordinator), **sub-agent** (hyphenated).
+
+---
+
+## Problem Statement
+
+Sub-agents in the project-team workflow (and any multi-agent workflow) have two
+gaps in how they receive phase-specific instructions:
+
+1. **Phase transitions are coordinator-only.** When `advance_phase` succeeds,
+   only the coordinator's phase context is updated. Running sub-agents are never
+   notified and continue operating under stale phase file content.
+
+2. **`spawn_agent` without `type=` skips agent prompt assembly.** When the
+   coordinator omits the `type` parameter, `spawn_agent` falls back to using the
+   agent `name` as the role lookup key (`role_name=agent_type or name` in
+   `mcp.py:279`), which fails silently on case-sensitive filesystems (NFS,
+   Linux) because agent names are capitalized (e.g., `"Skeptic"`) while role
+   folders are lowercase (e.g., `skeptic/`). The sub-agent receives the spawn
+   prompt but no agent prompt.
+
+3. **Premature agent closure.** The coordinator can close sub-agents at any
+   time, including during active phases where those agents are needed.
+
+---
+
+## Fix 1: Guardrail on `spawn_agent` Without `type=`
+
+### Placement: Workflow-Specific
+
+**File:** `workflows/project_team/project_team.yaml` (in the `rules:` section)
+
+**Rationale:** This is a workflow-specific rule, not a global one. Not all
+workflows use the agent folder/role system. A global rule would fire for simple
+multi-agent use cases where `type` is irrelevant (e.g., spawning a quick
+helper agent outside any workflow). The project-team workflow specifically
+requires role-based agent prompts, so the rule belongs in its manifest.
+
+### Rule Definition
+
+```yaml
+# In workflows/project_team/project_team.yaml, rules: section
+
+- id: spawn_agent_requires_type
+  trigger: PreToolUse/mcp__chic__spawn_agent
+  enforcement: warn
+  detect:
+    pattern: "^(?!.*\"type\"\\s*:).*$"
+    field: __raw__
+  message: |
+    spawn_agent called without type= parameter. Sub-agents need type= set
+    to their role folder name (e.g. type="composability") to receive their
+    agent prompt (identity file + phase file). Acknowledge if this agent
+    intentionally has no role.
+```
+
+### Design Notes
+
+- **`warn` not `deny`:** There are legitimate cases where a sub-agent has no
+  role (e.g., a temporary utility agent). `warn` forces acknowledgment but
+  allows override.
+- **Detection challenge:** The `detect` field matching works on a single
+  `tool_input` field. MCP tool inputs are JSON objects, not single strings.
+  The `__raw__` pseudo-field would need to be the JSON-serialized input.
+
+  **Alternative approach (simpler, preferred):** Instead of a guardrail rule
+  (which operates on string pattern matching of tool input fields), handle
+  this directly in `spawn_agent` in `mcp.py`. When a workflow is active and
+  `type` is not provided, emit a warning in the tool response:
+
+  ```python
+  # In spawn_agent, after creating the agent but before sending prompt:
+  if _app._workflow_engine and not agent_type:
+      result += (
+          "\n[WARNING] No type= specified. This agent will not receive "
+          "role-specific phase instructions. Set type= to a role folder "
+          "name to enable agent prompt injection."
+      )
+  ```
+
+  This is simpler, more reliable, and doesn't require pattern matching on
+  JSON. **Recommended over the guardrail approach.**
+
+### Fix 1b: Remove `agent_type or name` Fallback in `spawn_agent`
+
+The fallback `role_name=agent_type or name` in `mcp.py:279` is a **dirty
+seam** -- it conflates agent display name (user-facing, capitalized, e.g.,
+`"Skeptic"`) with role folder name (filesystem, lowercase, e.g., `skeptic/`).
+On case-sensitive filesystems (NFS, Linux, macOS default), `"Skeptic"` does
+not match `skeptic/`, so the lookup fails silently and no agent prompt is
+injected.
+
+**Fix:** Remove the `or name` fallback entirely. If `agent_type` is `None`,
+skip agent prompt assembly (the warning from Fix 1 already tells the
+coordinator what happened).
+
+```python
+# Current (mcp.py:276-279):
+folder_prompt = assemble_phase_prompt(
+    workflows_dir=Path.cwd() / "workflows",
+    workflow_id=_app._workflow_engine.workflow_id,
+    role_name=agent_type or name,  # BUG: name is capitalized, folder is lowercase
+    current_phase=_app._workflow_engine.get_current_phase(),
+)
+
+# Fixed:
+if agent_type:
+    folder_prompt = assemble_phase_prompt(
+        workflows_dir=Path.cwd() / "workflows",
+        workflow_id=_app._workflow_engine.workflow_id,
+        role_name=agent_type,
+        current_phase=_app._workflow_engine.get_current_phase(),
+    )
+else:
+    folder_prompt = None
+```
+
+**Why not `role_name.lower()` instead?** Because:
+- It papers over the seam instead of cleaning it. Agent names are display
+  strings; role folders are filesystem identifiers. They are different axes.
+- It introduces a new assumption ("all role folders are lowercase") that isn't
+  enforced anywhere.
+- The `name` fallback is inherently fragile regardless of case -- agent names
+  like `"Composability-2"` or `"review-skeptic"` won't match folder names.
+- The `type` parameter exists precisely to be the explicit link to the role
+  folder. Making the fallback "work sometimes" masks the real problem (missing
+  `type=`).
+
+**Why not case-insensitive folder lookup?** Because:
+- Adds complexity (directory iteration) for a path that shouldn't be used.
+- NFS + case-insensitive search is slow and fragile.
+- Same fundamental problem: agent names aren't role identifiers.
+
+### Composability Assessment
+
+- **Workflow-specific rule:** Only fires for project-team. Other workflows
+  that use roles get the benefit if they add a similar rule. Workflows without
+  roles are unaffected.
+- **Code-level warning (preferred approach):** Works for ALL workflows
+  automatically since it checks `_app._workflow_engine` presence, not a
+  specific workflow ID.
+
+---
+
+## Fix 2: Phase-Transition Broadcast in claudechic
+
+### Overview
+
+When `advance_phase` succeeds, iterate all running agents that have a stored
+role, assemble each one's agent prompt for the new phase, and deliver it via
+in-band delivery (`_send_prompt_fire_and_forget`).
+
+### Prerequisite: Store `agent_type` on the Agent Object
+
+**Current state:** `agent_type` is passed to `AgentManager.create()` and
+forwarded to `_make_options()` for environment variables and hooks, but is
+**never stored** on the `Agent` instance. The broadcast mechanism needs to
+know each agent's role at phase-transition time.
+
+**Change in `agent.py`:**
+
+```python
+class Agent:
+    def __init__(
+        self,
+        name: str,
+        cwd: Path,
+        *,
+        id: str | None = None,
+        worktree: str | None = None,
+        agent_type: str | None = None,  # NEW
+    ):
+        # ... existing fields ...
+        self.agent_type = agent_type  # NEW: role name for phase broadcast
+```
+
+**Change in `agent_manager.py`:**
+
+```python
+async def create(self, ..., agent_type: str | None = None) -> Agent:
+    agent = Agent(
+        name=name,
+        cwd=cwd,
+        worktree=worktree,
+        agent_type=agent_type,  # NEW: pass through
+    )
+    # ... rest unchanged ...
+```
+
+### Location: `mcp.py`, `_make_advance_phase()`, After Successful Advance
+
+Insert after the existing `_inject_phase_prompt_to_main_agent` call (after
+line ~867 in current code), inside the `if result.success:` block:
+
+```python
+# Broadcast phase update to all typed sub-agents
+if _app.agent_mgr:
+    from claudechic.workflows.agent_folders import assemble_phase_prompt
+
+    for agent in _app.agent_mgr.agents.values():
+        # Skip: coordinator (already handled above), agents without
+        # roles, and the calling agent (gets phase in tool response)
+        if not agent.agent_type:
+            continue
+        if agent.agent_type == main_role:
+            continue
+        if agent.name == caller_name:
+            continue
+
+        try:
+            agent_prompt = assemble_phase_prompt(
+                workflows_dir=Path.cwd() / "workflows",
+                workflow_id=engine.workflow_id,
+                role_name=agent.agent_type,
+                current_phase=next_phase,
+            )
+            if agent_prompt:
+                _send_prompt_fire_and_forget(
+                    agent,
+                    f"[Phase transition: {next_phase}]\n\n"
+                    f"Your updated phase instructions:\n\n"
+                    f"{agent_prompt}",
+                )
+        except Exception:
+            log.debug(
+                "Failed to broadcast phase to '%s'",
+                agent.name,
+                exc_info=True,
+            )
+```
+
+### Edge Cases
+
+| Edge Case | Handling |
+|-----------|----------|
+| Agent has no `agent_type` | Skipped (no role = no phase file to look up). No `name` fallback -- see Fix 1b. |
+| Agent has `agent_type` but no phase file exists for the new phase | `assemble_phase_prompt` returns identity file only, or `None` if no role folder exists. If `None`, skip. If identity-only, still deliver (re-anchors identity after long conversations). |
+| Dead/closed agents | Not in `agent_mgr.agents` iterator -- naturally excluded |
+| Coordinator agent | Skipped via `agent.agent_type == main_role` check. Coordinator gets phase context via filesystem injection (existing mechanism). |
+| Calling agent (the one that called `advance_phase`) | Skipped via `agent.name == caller_name`. Caller already receives phase instructions in the `advance_phase` tool response. |
+| Agent is busy | `_send_prompt_fire_and_forget` queues the message. It will be delivered when the agent's current task completes. This is correct behavior -- don't interrupt work, queue the update. |
+| Multiple agents with same role | Each gets the same agent prompt. This is correct -- same role = same instructions. |
+
+### The `encoding='utf-8'` Fix in `agent_folders.py`
+
+Per cross-platform rules (CLAUDE.md), all `read_text()` calls must pass
+`encoding='utf-8'`. Two violations exist in `_assemble_agent_prompt`:
+
+```python
+# Current (broken on Windows):
+identity = identity_path.read_text() if identity_path.is_file() else ""
+phase_content = phase_path.read_text()
+
+# Fixed:
+identity = identity_path.read_text(encoding="utf-8") if identity_path.is_file() else ""
+phase_content = phase_path.read_text(encoding="utf-8")
+```
+
+This is a mandatory fix regardless of the other changes.
+
+### Composability Assessment
+
+- **Fully generic.** The broadcast iterates `agent_mgr.agents` and uses
+  `assemble_phase_prompt()` -- both are workflow-agnostic. Any workflow that
+  defines role folders gets broadcast for free.
+- **No-op safe.** If a workflow has no role folders, or agents have no
+  `agent_type`, the broadcast does nothing. Zero cost for simple workflows.
+- **Follows the algebraic law.** The law is: "every agent with a role gets
+  its role's agent prompt at every phase lifecycle event." Spawn-time
+  injection already follows this law. This fix extends it to phase transitions.
+  PostCompact re-injection already follows it. All three mechanisms use the
+  same `assemble_phase_prompt()` function -- the shared protocol.
+
+---
+
+## Fix 3: `close_agent` Guardrail
+
+### Placement: Workflow-Specific
+
+**File:** `workflows/project_team/project_team.yaml` (in the `rules:` section)
+
+**Rationale:** Like Fix 1, this is specific to workflows where sub-agents have
+persistent roles across phases. Not all multi-agent uses require agent
+persistence -- utility agents should be closeable freely.
+
+### Rule Definition
+
+```yaml
+# In workflows/project_team/project_team.yaml, rules: section
+
+- id: no_close_leadership
+  trigger: PreToolUse/mcp__chic__close_agent
+  enforcement: warn
+  roles: [coordinator]
+  exclude_phases: [signoff]
+  message: |
+    Closing a Leadership agent before signoff phase. These agents provide
+    continuity across phases. Acknowledge if this agent's work is truly
+    complete for the remainder of the project.
+```
+
+### Design Decisions
+
+- **`warn` not `deny`:** There are valid reasons to close an agent early
+  (e.g., agent is stuck, role is genuinely complete). `warn` forces the
+  coordinator to explicitly acknowledge, creating an audit trail via the
+  hit logger, but doesn't hard-block.
+
+- **`roles: [coordinator]`:** Only the coordinator can close other agents
+  (sub-agents can't close each other -- `mcp.py` prevents self-close but
+  doesn't restrict cross-agent closes). Scoping to coordinator means the
+  rule only fires for the primary orchestrator.
+
+- **`exclude_phases: [signoff]`:** In the signoff phase, closing agents is
+  expected cleanup. No warning needed.
+
+- **No per-role uncloseable list:** Instead of listing which roles can't be
+  closed, the rule warns on ALL closes during active phases. This is simpler
+  and catches unexpected closures of any role. The coordinator can acknowledge
+  to proceed.
+
+### Alternative Considered: Deny-Level with Role Allowlist
+
+```yaml
+# NOT recommended:
+- id: no_close_leadership
+  trigger: PreToolUse/mcp__chic__close_agent
+  enforcement: deny
+  detect:
+    pattern: "(composability|skeptic|user_alignment|terminology_guardian)"
+    field: name
+  message: "Cannot close Leadership agent. Request override if necessary."
+```
+
+**Rejected because:**
+- Hardcodes role names (breaks for other workflows)
+- `deny` requires user override prompt (too disruptive for a common operation)
+- Pattern matching on the `name` field is fragile (agent names may differ from role names)
+
+### Composability Assessment
+
+- **Workflow-specific:** Only project-team gets this rule. Other workflows can
+  add similar rules if they have persistent agents.
+- **Role-based scoping:** `roles: [coordinator]` means the rule only evaluates
+  for the coordinator agent, which is the one that typically closes others.
+- **Phase-based scoping:** `exclude_phases: [signoff]` correctly allows cleanup
+  in the final phase.
+
+---
+
+## Implementation Order
+
+1. **`encoding='utf-8'` fix** (agent_folders.py) -- standalone, no dependencies,
+   cross-platform mandatory.
+
+2. **Remove `or name` fallback + add type warning** (mcp.py) -- Fix 1 + Fix 1b.
+   These go together: remove the broken fallback and add a clear warning when
+   `type` is missing during an active workflow.
+
+3. **Store `agent_type` on Agent** (agent.py + agent_manager.py) -- prerequisite
+   for broadcast. Small change, no behavioral impact on its own.
+
+4. **Phase-transition broadcast** (mcp.py) -- the core fix. Depends on step 3.
+
+5. **Guardrail rules** (project_team.yaml) -- standalone, can be done in
+   parallel. `close_agent` warning + optionally `spawn_agent` warn rule.
+
+6. **Phase files for sub-agent roles** -- content work, depends on step 4
+   (broadcast mechanism) to be useful. Out of scope for this spec but
+   tracked as follow-up.
+
+---
+
+## Testing Strategy
+
+### Unit Tests (in `submodules/claudechic/tests/`)
+
+1. **`test_agent_type_stored`:** Verify `Agent(agent_type="foo").agent_type == "foo"`.
+
+2. **`test_broadcast_on_advance`:** Mock `agent_mgr.agents` with typed agents,
+   call `advance_phase`, verify `_send_prompt_fire_and_forget` called for each
+   typed agent with correct role-specific agent prompt.
+
+3. **`test_broadcast_skips_coordinator`:** Verify agent with `agent_type == main_role`
+   is not broadcast to.
+
+4. **`test_broadcast_skips_untyped`:** Verify agent with `agent_type=None` is skipped.
+
+5. **`test_broadcast_no_phase_file`:** Verify agent whose role has no phase file
+   for the new phase receives identity-only content (or is skipped if no role
+   folder exists).
+
+6. **`test_encoding_utf8`:** Verify `_assemble_agent_prompt` reads files with
+   `encoding='utf-8'` (already covered by `test_utf8_encoding.py` pattern CI).
+
+### Integration Tests (in `tests/`)
+
+7. **`test_guardrail_close_leadership`:** Verify the `no_close_leadership` rule
+   fires `warn` for coordinator closing an agent in specification phase, and
+   does NOT fire in signoff phase.
+
+8. **`test_guardrail_spawn_without_type`:** If using the guardrail approach,
+   verify the rule fires when `spawn_agent` is called without `type`.
+
+### Markers
+
+All new tests should use the `fast` marker (default) since they are unit/mock
+tests. No real SDK connections needed.
+
+---
+
+## Files Modified
+
+| File | Layer | Change |
+|------|-------|--------|
+| `submodules/claudechic/claudechic/agent.py` | claudechic | Add `agent_type` parameter and attribute to `Agent.__init__` |
+| `submodules/claudechic/claudechic/agent_manager.py` | claudechic | Pass `agent_type` to `Agent()` constructor |
+| `submodules/claudechic/claudechic/mcp.py` | claudechic | Remove `or name` fallback (Fix 1b); add type warning (Fix 1); store `agent_type` on agent at spawn; broadcast on phase advance (Fix 2) |
+| `submodules/claudechic/claudechic/workflows/agent_folders.py` | claudechic | Add `encoding='utf-8'` to `read_text()` calls |
+| `workflows/project_team/project_team.yaml` | template source | Add `no_close_leadership` and optionally `spawn_agent_requires_type` rules |
+
+---
+
+## What This Spec Does NOT Cover
+
+- **Writing phase files for sub-agent roles.** This is content work, not
+  architecture. The broadcast mechanism must exist first (otherwise phase files
+  are dead code). Tracked as follow-up work.
+
+- **Interrupting busy agents on phase transition.** The current design queues
+  phase updates (fire-and-forget). If an agent is in the middle of a long task,
+  it won't see the update until that task completes. This is intentional --
+  interrupting mid-task is disruptive and the agent will get the update soon.
+  If immediate interruption is needed, the coordinator can use `interrupt_agent`.
+
+- **Per-agent phase context files.** The spec uses in-band delivery (chat
+  messages) for sub-agents, not per-agent `.claude/phase_context.md` files.
+  This avoids filesystem complexity and works with the existing PostCompact
+  re-injection mechanism for context persistence.

--- a/.project_team/subagent_phase_injection/STATUS.md
+++ b/.project_team/subagent_phase_injection/STATUS.md
@@ -1,0 +1,29 @@
+# Project: subagent_phase_injection
+# Issue: #37
+
+## Phase: setup
+## Status: in-progress
+
+## Vision
+Investigate and fix how sub-agents receive (or fail to receive) their role-specific
+phase instructions in the project-team workflow -- both at spawn time and during
+phase transitions. Also address premature agent closure.
+
+## What We Know
+- phase_context.md is assembled for the coordinator only
+- Sub-agents receive coordinator-authored prompts, not their role phase files
+- No automated mechanism to inject context to running sub-agents on phase transition
+- Coordinator can close agents at any point
+
+## What We Need to Discover
+- What exactly does the coordinator send to sub-agents vs. the actual phase markdown?
+- What happens to running sub-agents when a phase advances?
+- Which phases and roles are most affected?
+- What fix patterns work best (guardrails, claudechic changes, workflow changes, hybrid)?
+
+## Possible Fix Directions
+1. Guardrail rules (warn/deny on spawn_agent, close_agent, advance_phase, tell_agent)
+2. claudechic system fix (auto-inject at spawn/transition)
+3. Workflow-level fix (restructure project-team to handle context delivery)
+4. Hybrid across layers
+5. Team-discovered alternatives

--- a/.project_team/subagent_phase_injection/TESTING_PLAN.md
+++ b/.project_team/subagent_phase_injection/TESTING_PLAN.md
@@ -1,0 +1,81 @@
+# Manual Testing Plan: Sub-Agent Phase Injection (#37)
+
+After restarting claudechic, follow these steps to verify each fix works in a live session.
+
+## Setup
+
+The project-team workflow should already be active. If not, activate it with `/project-team`.
+
+---
+
+## Test 1: prefer_ask_agent rule fires for coordinator
+
+**What it proves:** Main agent role resolves to `coordinator` from `main_role`. Rules with `roles: [coordinator]` fire for the main agent.
+
+1. Spawn a test agent: `spawn_agent name="TestDummy" type="skeptic" prompt="Wait for instructions"`
+2. Use `tell_agent` to TestDummy with any message
+3. **Expected:** Warning fires -- "Coordinator should use ask_agent, not tell_agent"
+4. Use `ask_agent` to TestDummy with any message
+5. **Expected:** Goes through clean, no warning
+
+---
+
+## Test 2: no_close_leadership rule blocks close
+
+**What it proves:** Agents cannot be closed before signoff phase.
+
+6. Try to close TestDummy with `close_agent`
+7. **Expected:** Blocked with "Do not close agents during active workflow phases"
+8. You can acknowledge the warning to override if needed
+
+---
+
+## Test 3: spawn warning when type= omitted
+
+**What it proves:** Coordinator gets warned when spawning without role context.
+
+9. Spawn agent WITHOUT type=: `spawn_agent name="NoTypeAgent" prompt="Just a helper"`
+10. **Expected:** Response contains `[WARNING] No type= specified. This agent will not receive role-specific phase instructions.`
+
+---
+
+## Test 4: Phase broadcast to sub-agents
+
+**What it proves:** Typed sub-agents get phase files when the workflow advances.
+
+11. Make sure TestDummy (type="skeptic") is still running
+12. Advance phase (e.g., implementation -> testing)
+13. **Check TestDummy's chat** -- should show `--- Phase Update: testing ---` followed by skeptic/testing.md content
+14. **Check YOUR chat (coordinator)** -- should NOT get a broadcast message (phase content is inline in the advance_phase tool response only)
+15. **Check NoTypeAgent** -- should NOT get a broadcast (it has no type=)
+
+---
+
+## Test 5: Name fallback removed
+
+**What it proves:** Agent named like a role folder does NOT get that role's content unless type= is explicitly set.
+
+16. Spawn agent: `spawn_agent name="coordinator" prompt="I am just a helper"`
+17. **Check its first message** -- should be ONLY the prompt you gave
+18. **Expected:** NO identity.md content prepended (no "You are the coordinator" text)
+
+---
+
+## Expected Results Summary
+
+| Action | Expected Result |
+|--------|----------------|
+| `tell_agent` from coordinator | Warning: prefer_ask_agent |
+| `close_agent` before signoff | Blocked: no_close_leadership |
+| `spawn_agent` without type= | Success + [WARNING] in response |
+| `advance_phase` with typed agents | Typed agents get phase content |
+| `advance_phase` with untyped agents | Untyped agents get nothing |
+| Agent named "coordinator" no type= | No identity.md injected |
+
+---
+
+## If something fails
+
+- Check `get_phase` to verify workflow is active and rules are loaded (should show 27+ rules)
+- Check `whoami` to see your agent name
+- The dynamic role resolution requires a workflow to be active -- rules with `roles: [coordinator]` won't fire if no workflow is activated

--- a/.project_team/subagent_phase_injection/composability_report.md
+++ b/.project_team/subagent_phase_injection/composability_report.md
@@ -1,0 +1,216 @@
+# Composability Analysis: Sub-Agent Phase Injection (#37)
+
+**Author:** Composability (Lead Architect)
+**Date:** 2026-04-15
+
+---
+
+## Domain Understanding
+
+The system has a multi-agent workflow engine where a **coordinator agent** spawns **sub-agents** with specific roles (e.g., Composability, Skeptic, UserAlignment). Each role has per-phase markdown instructions (`identity.md` + `{phase}.md`) stored in `workflows/{workflow}/{role}/`. The problem: sub-agents don't reliably receive their role-specific phase instructions, and running sub-agents aren't updated when the phase transitions.
+
+---
+
+## Architectural Analysis: Three Layers
+
+### Layer 1: claudechic (Core Engine)
+
+#### What spawn_agent currently does (mcp.py lines 267-294)
+
+**Good news: spawn-time injection already exists.** When `_app._workflow_engine` is active and a prompt is provided, `spawn_agent` calls `assemble_phase_prompt()` with the agent's `type` (role) and prepends the role-specific phase markdown to the coordinator's prompt. This means:
+
+- `assemble_phase_prompt(workflow_id, role_name=agent_type, current_phase)` is called
+- The result (identity.md + phase.md for that role) is prepended to the coordinator's spawn prompt
+- The full prompt is: `{role_phase_markdown}\n\n---\n\n{coordinator_prompt}`
+
+**The real gap is NOT at spawn time -- it's at phase transition time.**
+
+#### What advance_phase does (mcp.py lines 793-878)
+
+When `advance_phase` succeeds:
+
+1. It assembles phase prompt for `main_role` only (the coordinator's role)
+2. It calls `_inject_phase_prompt_to_main_agent()` which writes to `.claude/phase_context.md`
+3. `.claude/phase_context.md` is a single file that becomes part of the system prompt
+
+**Critical gap:** `advance_phase` never notifies running sub-agents. The `_inject_phase_prompt_to_main_agent` method name says it all -- it only targets the main agent. There is NO iteration over `agent_mgr.agents` to send phase updates to sub-agents.
+
+#### What _write_phase_context does (app.py lines 1702-1747)
+
+Writes to `.claude/phase_context.md` for ONE role only (always `main_role`). This is a single shared file -- it cannot contain instructions for multiple roles simultaneously. Sub-agents read the same `.claude/phase_context.md` and get the coordinator's phase instructions, not their own.
+
+#### PostCompact hook (agent_folders.py lines 105-146)
+
+The PostCompact hook re-injects phase context after `/compact`. It captures `agent_role` at creation time and correctly uses the agent's own role. **This is the one place where per-role context is handled correctly for sub-agents** -- but only after compaction, not on phase transitions.
+
+### Layer 2: Guardrails System
+
+The guardrail hook pipeline (`hooks.py`) operates on `PreToolUse` events. It:
+
+- Receives `agent_role` at hook creation time (captured in closure)
+- Can match on tool name, detect patterns, and phases
+- Can block, warn, or log
+
+**Key observation:** Guardrails fire on MCP tool calls (`PreToolUse/spawn_agent`, `PreToolUse/advance_phase`). They CAN detect when spawn_agent or advance_phase is called, but they operate in the **blocking** paradigm (block/warn/allow). They are not designed for **injection** of additional context into tool responses. The `Injection` mechanism modifies `tool_input` fields, which is for command rewriting, not for adding system context.
+
+### Layer 3: Workflow Definitions / Template
+
+The workflow YAML and role folder structure (`workflows/project_team/{role}/{phase}.md`) contain the actual content. This layer is correct -- the content exists and is properly organized per-role and per-phase.
+
+---
+
+## Composability Axes
+
+### Axis 1: WHO (Agent Role)
+- Values: coordinator, composability, skeptic, user_alignment, terminology_guardian, ...
+- Each role has its own identity.md and per-phase markdown
+- This axis is well-separated at the content layer
+
+### Axis 2: WHEN (Phase Lifecycle Event)
+- Values: spawn-time, phase-transition, post-compact, mid-task
+- Each event type has a different injection mechanism (or lacks one)
+- **This axis has holes** -- phase-transition doesn't serve sub-agents
+
+### Axis 3: WHAT (Content Type)
+- Values: identity, phase instructions, coordinator prompt
+- These compose cleanly (identity + phase = full context)
+- The `assemble_phase_prompt()` function handles this correctly
+
+### Axis 4: HOW (Delivery Mechanism)
+- Values: file-based (.claude/phase_context.md), inline (prepended to prompt), message (send to agent)
+- **This axis has dirty seams** -- file-based assumes one role per project, inline works for any role
+
+---
+
+## Crystal Analysis: Holes Identified
+
+### Hole 1: Phase transition x Sub-agents (CRITICAL)
+
+| Event | Coordinator | Sub-agents |
+|-------|-------------|------------|
+| Spawn | identity + phase (via file) | identity + phase (inline) -- WORKS |
+| Phase advance | Updated via file + tool response | **NOTHING** -- NOT NOTIFIED |
+| Post-compact | Re-injected via hook | Re-injected via hook -- WORKS |
+
+The crystal has a gaping hole at (phase-transition, sub-agent). This is the core bug.
+
+### Hole 2: File-based delivery is single-role
+
+`.claude/phase_context.md` can only contain ONE role's instructions. When a sub-agent reads it (which all agents in the same directory do), they get the coordinator's instructions. This is a fundamental design flaw in using a shared file for per-role content.
+
+### Hole 3: No sub-agent registry for broadcast
+
+When `advance_phase` fires, the engine has no notion of "all agents with roles that need phase updates." The `agent_mgr` has all agents, and each agent has an `agent_type` attribute, but `advance_phase` never iterates over them.
+
+---
+
+## Proposed Fix Directions
+
+### Direction A: claudechic System Fix (Auto-Injection at Phase Transition)
+
+**Where:** `mcp.py` `_make_advance_phase()`, after successful advance
+
+**What:** After advancing, iterate over all running agents that have an `agent_type`, assemble their role-specific phase prompt, and send it via `_send_prompt_fire_and_forget()`.
+
+```python
+# After the existing _inject_phase_prompt_to_main_agent call:
+if _app.agent_mgr:
+    for agent in _app.agent_mgr.agents.values():
+        if agent.agent_type and agent.name != caller_name:
+            try:
+                phase_prompt = assemble_phase_prompt(
+                    workflows_dir=Path.cwd() / "workflows",
+                    workflow_id=engine.workflow_id,
+                    role_name=agent.agent_type,
+                    current_phase=next_phase,
+                )
+                if phase_prompt:
+                    _send_prompt_fire_and_forget(
+                        agent,
+                        f"--- Phase Transition: {next_phase} ---\n\n{phase_prompt}",
+                    )
+            except Exception:
+                log.debug("Failed to inject phase to %s", agent.name, exc_info=True)
+```
+
+**Composability assessment:** This is the ALGEBRAIC fix. It follows the law: "every agent with a role gets its role's phase content at every lifecycle event." It works for ANY workflow, not just project-team. New workflows automatically benefit.
+
+**Tradeoffs:**
+- Sub-agents receive phase updates as chat messages (not system prompt), which means they may be compacted away. But the PostCompact hook already handles that.
+- If a sub-agent is busy, the message queues (which is correct behavior).
+- The coordinator can still send task-specific context in addition.
+
+### Direction B: Guardrail Rule (Warn/Deny on spawn_agent without phase context)
+
+**Where:** `global/rules.yaml` or workflow YAML `rules:` section
+
+**What:** A guardrail rule that detects `spawn_agent` calls and warns if the `prompt` field doesn't contain phase-relevant keywords.
+
+**Composability assessment:** This is a BAND-AID, not a fix. It works for the spawn-time case but:
+- Cannot detect missing phase context in the prompt content reliably (pattern matching on natural language)
+- Does nothing for phase transitions
+- Adds friction without solving the root cause
+- Workflow-specific rules would need per-workflow configuration
+
+**Verdict:** Low value. The spawn-time injection already works in claudechic. The real problem is phase transitions, and guardrails can't inject messages into agents.
+
+### Direction C: Workflow Definition Fix
+
+**Where:** `workflows/project_team/coordinator/` phase files
+
+**What:** Add explicit instructions to the coordinator's phase markdown telling it to relay phase context to sub-agents using `tell_agent`.
+
+**Composability assessment:** This WORKS but is NOT ALGEBRAIC. It relies on:
+- The coordinator following instructions correctly (unreliable)
+- The coordinator summarizing/relaying content (lossy)
+- Every workflow author remembering to add these instructions
+- The coordinator not being busy or ignoring the instruction
+
+**Verdict:** Useful as a safety net (defense in depth) but should not be the primary mechanism. The coordinator may still choose to summarize or omit content.
+
+### Direction D: Hybrid (RECOMMENDED)
+
+Combine Direction A (claudechic auto-injection) + Direction C (workflow instructions as fallback):
+
+1. **Primary:** claudechic auto-injects phase content to all typed agents on phase transition (Direction A). This is the algebraic, works-for-all-workflows fix.
+
+2. **Secondary:** Workflow phase instructions include a note like "Ensure sub-agents have acknowledged their phase transition" -- this gives the coordinator awareness without making it the sole mechanism.
+
+3. **Optional enhancement:** Add a `get_phase` enhancement that shows each agent's role and whether they've received the current phase content. This gives visibility.
+
+---
+
+## Seam Analysis
+
+### Seam: spawn_agent <-> assemble_phase_prompt
+
+**Status: CLEAN.** The `assemble_phase_prompt()` function takes `(workflows_dir, workflow_id, role_name, current_phase)` and returns `str | None`. It doesn't know about agents, MCP, or the TUI. The caller (spawn_agent) handles delivery.
+
+### Seam: advance_phase <-> phase delivery
+
+**Status: DIRTY.** `advance_phase` hardcodes delivery to `main_role` only. The concept of "who needs phase content" is not abstracted -- it's baked into the single call to `_inject_phase_prompt_to_main_agent`. The method name encodes the assumption.
+
+**Fix:** The delivery logic should iterate over all agents with roles, using the same `assemble_phase_prompt()` function with each agent's role. The seam between "what phase are we in" and "who needs to know" should be explicit.
+
+### Seam: .claude/phase_context.md <-> Claude Code system prompt
+
+**Status: INHERENTLY SINGLE-ROLE.** This file-based mechanism can only serve one role. For multi-role support, either:
+- Each agent needs its own context file (complex, requires per-agent `.claude/` directories)
+- Sub-agents get phase content via chat messages instead of system prompt (simpler, and compaction is already handled)
+
+The inline approach (chat messages) is the pragmatic choice since the PostCompact hook already handles re-injection.
+
+---
+
+## Summary
+
+| Fix Direction | Fixes Spawn | Fixes Phase Transition | Works for All Workflows | Complexity |
+|---------------|-------------|----------------------|------------------------|------------|
+| A: claudechic auto-inject | Already works | YES | YES (algebraic) | Low-medium |
+| B: Guardrail rules | Partial | NO | NO | Low |
+| C: Workflow instructions | Depends on coordinator | Unreliable | NO (per-workflow) | Low |
+| D: Hybrid (A+C) | YES | YES | YES | Medium |
+
+**Recommendation:** Direction D (Hybrid), with Direction A as the primary fix in claudechic. The fix is ~20 lines of code in `mcp.py`'s `advance_phase`, follows the existing `assemble_phase_prompt` law, and benefits all workflows automatically.
+
+The close_agent issue mentioned in the STATUS.md is a separate concern -- it's about the coordinator prematurely closing agents, which is a workflow instruction / guardrail problem, not a phase injection problem.

--- a/.project_team/subagent_phase_injection/researcher_chic_sessions.md
+++ b/.project_team/subagent_phase_injection/researcher_chic_sessions.md
@@ -1,0 +1,298 @@
+# Chicsession Analysis: What Skeptic Actually Received
+
+**Author:** Researcher agent
+**Date:** 2026-04-15
+**Issue:** #37
+**Method:** Direct comparison of raw JSONL session data from `.chicsessions/` pointers to Claude session files
+
+---
+
+## Executive Summary
+
+**SMOKING GUN FOUND.** The Cluster2 chicsession (2026-04-10) uses the `project-team` workflow but the coordinator spawned the Skeptic **without the `type=` parameter**. The Skeptic received ONLY the coordinator's freeform prompt -- zero identity.md, zero phase files. The current session (Inject_Bug37, 2026-04-15) DOES pass `type="skeptic"` -- confirming the fix works but proving the problem was real in prior sessions.
+
+---
+
+## Data Sources
+
+### Chicsession Files (`.chicsessions/`)
+
+These are JSON metadata files containing agent names, session UUIDs, and workflow state. The actual conversation data lives in `~/.claude/projects/-groups-spruston-home-moharb-AI-PROJECT-TEMPLATE/{session_id}.jsonl`.
+
+| Chicsession | Date | Workflow | Phase | Agents |
+|-------------|------|----------|-------|--------|
+| **Inject_Bug37** | 2026-04-15 | project-team | leadership | 6 (Coord, Comp, Term, Skeptic, UA, Researcher) |
+| **Cluster2** | 2026-04-11 | project-team | signoff | 11 (Coord + 4 leadership + 4 implementers + TestEngineer + Researcher) |
+| **Backend** | 2026-04-11 | project-team | specification | 5 (Coord + 4 SpecReviewers) |
+| **project-team** | 2026-04-10 | project-team | signoff | 1 (Coord only - agents already closed) |
+
+### Session JSONL Files Used
+
+| Agent | Session UUID | Source Chicsession |
+|-------|-------------|-------------------|
+| Coordinator (Cluster2) | `95eb7cca-b5df-4f28-996b-a9ae71c3309f` | Cluster2 |
+| Skeptic (Cluster2) | `0a8174c2-03a6-4e5d-b44e-40cb9f066728` | Cluster2 |
+| Coordinator (current) | `0b8e7bba-aa88-4d22-984d-a2628c356eba` | Inject_Bug37 |
+
+---
+
+## Evidence Exhibit A: Cluster2 Session -- Skeptic Spawn (NO `type=` parameter)
+
+### Raw JSONL from coordinator session (line 76)
+
+The coordinator's `spawn_agent` call:
+
+```json
+{
+  "name": "mcp__chic__spawn_agent",
+  "input": {
+    "name": "Skeptic",
+    "path": "/groups/spruston/home/moharb/AI_PROJECT_TEMPLATE",
+    "requires_answer": true,
+    "prompt": "You are the **Skeptic** leadership agent for the \"bootstrapping_bridge\" project.\n\n## Your Role\nChallenge assumptions, identify risks, failure modes, and over-engineering. Push back on unnecessary complexity.\n\n## Context\n..."
+  }
+}
+```
+
+**CRITICAL: No `"type"` field.** The coordinator passed `name`, `path`, `requires_answer`, and `prompt` -- but NOT `type`.
+
+### What the Skeptic actually received (from Skeptic's JSONL, line 1)
+
+```
+[Spawned by agent 'AI_PROJECT_TEMPLATE']
+
+You are the **Skeptic** leadership agent for the "bootstrapping_bridge" project.
+
+## Your Role
+Challenge assumptions, identify risks, failure modes, and over-engineering.
+Push back on unnecessary complexity.
+
+## Context
+We're designing the **bootstrapping bridge** for AI_PROJECT_TEMPLATE --
+connecting Copier questionnaire (generation time) with runtime claudechic workflows.
+
+**The Problem:** Two-phase onboarding with no state handoff. Copier asks questions
+and generates stubs, runtime workflows ignore what was collected.
+
+**6 Seams identified:** cluster setup, git setup, codebase integration, claudechic mode,
+quick start presets, MCP tools.
+
+**Reference:** PR #18 converts cluster_setup from a markdown doc to a 7-phase
+executable workflow.
+
+## Your Task
+1. Read these files:
+   - /groups/spruston/home/moharb/AI_PROJECT_TEMPLATE/template/copier.yml
+   - /groups/spruston/home/moharb/AI_PROJECT_TEMPLATE/.project_team/bootstrapping_bridge/STATUS.md
+
+2. Challenge the following assumptions:
+   - Do we actually need a generic "bridge"? Or is this 2-3 specific fixes?
+   - Is the "two-phase onboarding" actually a problem users experience, or theoretical?
+   - How many of the 6 seams are real pain points vs nice-to-haves?
+   - Is re-verification actually BAD? Maybe it's a feature (validation)?
+   - Could we solve this by just making Copier ask LESS and letting workflows do MORE?
+   - What's the cost of building a generic bridge vs just fixing each seam individually?
+
+3. Identify risks:
+   - Over-engineering: are we building an abstraction nobody asked for?
+   - State synchronization: what happens when Copier and workflows disagree?
+   - Maintenance burden: does a bridge become another thing to keep in sync?
+   - User confusion: does adding a bridge layer make onboarding MORE complex?
+
+4. Propose the **simplest thing that could work** as a counterpoint to any elaborate design.
+
+Reply back with your critique using `tell_agent` to Coordinator.
+```
+
+### What the Skeptic identity.md contains (but was NOT sent)
+
+The full 117-line identity.md includes these critical sections that the Skeptic never received:
+
+**Missing: "Essential vs Accidental Complexity" framework:**
+```markdown
+## Essential vs Accidental Complexity
+
+- **Accidental complexity:** Complexity from poor design choices. Eliminate it.
+- **Essential complexity:** Complexity inherent to the problem. Solve it, don't avoid it.
+
+If the user explicitly asks for X and X is complex, the complexity is **essential**.
+Don't propose Y because Y is simpler -- propose how to make X as simple as possible
+while still being X.
+```
+
+**Missing: "Four Questions" evaluation framework:**
+```markdown
+## Four Questions
+
+1. "Does this fully solve what the user asked for?" -- Not an easier version. The actual requirement.
+2. "Is this complete?" -- No shortcuts. All inputs, all states, all paths handled.
+3. "Is complexity obscuring correctness?" -- Can we simplify while still solving the full problem?
+4. "Is simplicity masking incompleteness?" -- Are we proposing something simpler because it's
+   better, or because we're not solving the hard part?
+```
+
+**Missing: "Red Flags" checklist:**
+```markdown
+## Red Flags
+
+- "Works for the common case" -> shortcut, not solution
+- "Just do X first" -> burden shifted, not handled
+- "We can add that later" -> incomplete now, technical debt forever
+- Can't explain the flow in one sentence -> too complex to verify
+- "X is too hard, let's do Y instead" -> avoiding essential complexity
+- "This is simpler" (but solves a different problem) -> not simpler, just incomplete
+```
+
+**Missing: "On Verifiability" evaluation lens:**
+```markdown
+## On Verifiability
+
+Code is **verifiable** when you can *see* it's correct by reading it -- not hope,
+not "the tests pass."
+```
+
+**Missing: "Authority" bounds:**
+```markdown
+## Authority
+
+- You CAN demand complete solutions over shortcuts
+- You CAN push for simpler approaches that are easier to verify
+- You CANNOT accept shortcuts disguised as simplicity
+- You CANNOT cut features from userprompt.md
+```
+
+### What the phase file (leadership phase) would have added
+
+The Skeptic was spawned during the `leadership` phase. The Skeptic has NO `leadership.md` file -- so `assemble_phase_prompt()` would have returned just identity.md. But since `type=` was missing, even identity.md was not injected.
+
+---
+
+## Evidence Exhibit B: Current Session (Inject_Bug37) -- Skeptic Spawn (WITH `type=`)
+
+### Raw JSONL from coordinator session (line 95)
+
+```json
+{
+  "name": "mcp__chic__spawn_agent",
+  "input": {
+    "name": "Skeptic",
+    "path": "/groups/spruston/home/moharb/AI_PROJECT_TEMPLATE",
+    "type": "skeptic",
+    "requires_answer": true,
+    "prompt": "You are the Skeptic agent for issue #37: Sub-agent phase markdown not injected.\n\nRead /groups/spruston/home/moharb/AI_PROJECT_TEMPLATE/.project_team/subagent_phase_injection/STATUS.md for the full vision.\n\nYour job: Challenge assumptions and find risks. Investigate:\n\n1. Read submodules/claudechic/claudechic/mcp.py -- the spawn_agent function..."
+  }
+}
+```
+
+**`"type": "skeptic"` IS PRESENT.** This means `assemble_phase_prompt()` was called with `role_name="skeptic"`, found `workflows/project_team/skeptic/identity.md`, and prepended it to the coordinator's prompt.
+
+### What the Skeptic in the current session received
+
+```
+{identity.md content - all 117 lines}
+
+---
+
+{coordinator's freeform prompt about issue #37}
+```
+
+The Skeptic in THIS session got its full identity, including the Four Questions, the Red Flags, the Essential vs Accidental framework, and the Authority bounds.
+
+---
+
+## Evidence Exhibit C: Also Missing `type=` -- All Other Agents in Cluster2
+
+The same coordinator session (Cluster2, line 72) shows the Composability spawn:
+
+```json
+{
+  "name": "mcp__chic__spawn_agent",
+  "input": {
+    "name": "Composability",
+    "path": "/groups/spruston/home/moharb/AI_PROJECT_TEMPLATE",
+    "requires_answer": true,
+    "prompt": "You are the **Composability** leadership agent for the \"bootstrapping_bridge\" project..."
+  }
+}
+```
+
+**No `type` field.** Same pattern for Terminology (line 74), UserAlignment (line 78), and Researcher.
+
+In contrast, the current session (Inject_Bug37) passes `type=` for ALL agents:
+- Line 91: `"type": "composability"`
+- Line 93: `"type": "terminology"`
+- Line 95: `"type": "skeptic"`
+- Line 97 (likely): `"type": "user_alignment"` or similar
+
+---
+
+## Evidence Exhibit D: Backend Session -- Non-Standard Agent Names
+
+The Backend chicsession used agent names that DON'T match role folders:
+- `SpecReviewer-Arch`, `SpecReviewer-Risk`, `SpecReviewer-UX`, `SpecReviewer-Code`
+
+These names have no corresponding `workflows/project_team/specreviewer-arch/` directory. Even WITH `type=`, these agents would receive nothing unless they use a `type` that maps to an existing role folder. Without `type=`, the fallback logic uses `agent_type or name` (mcp.py line 279), which would try `SpecReviewer-Arch` as the role name -- which doesn't exist.
+
+---
+
+## Side-by-Side: What Was Lost
+
+### Cluster2 Skeptic (NO identity injection)
+
+| Skeptic Identity Component | Present? | Impact |
+|---------------------------|----------|--------|
+| "Complete, Correct, Simple -- in that order" principle | NO | Agent lacks the priority framework |
+| Essential vs Accidental Complexity framework | NO | Agent can't distinguish problem complexity from design complexity |
+| Four Questions evaluation method | NO | Agent reviews without structured methodology |
+| "Simplicity in Code vs Tests" distinction | NO | Agent might over-simplify tests |
+| Verifiability evaluation lens | NO | Agent doesn't know to check if code is verifiable by reading |
+| Red Flags checklist | NO | Agent misses common anti-patterns |
+| Authority bounds | NO | Agent doesn't know what it can/can't demand |
+| Communication protocol | NO | Agent may use wrong inter-agent tools |
+
+### Current Session Skeptic (WITH identity injection)
+
+| Skeptic Identity Component | Present? | Impact |
+|---------------------------|----------|--------|
+| All of the above | YES | Full identity context available |
+| Phase-specific instructions | NO* | No `leadership.md` for Skeptic role |
+
+*The Skeptic's `specification.md`, `implementation.md`, and `testing.md` files exist but were NOT injected because the current phase is `leadership`, and there is no `skeptic/leadership.md`.
+
+---
+
+## The Evolution: What Changed Between Sessions
+
+| Aspect | Cluster2 (2026-04-10) | Inject_Bug37 (2026-04-15) |
+|--------|----------------------|--------------------------|
+| Workflow | `project-team` | `project-team` |
+| claudechic version | 2.1.87 | 2.1.87 |
+| Coordinator passes `type=` | **NO** | **YES** |
+| Sub-agents get identity.md | **NO** | **YES** |
+| Phase files injected | **NO** (no type + no matching phase file) | **PARTIALLY** (type passed, but no leadership.md for skeptic) |
+
+**The system code hasn't changed.** The `type=` parameter and `assemble_phase_prompt()` existed in BOTH sessions (same claudechic version 2.1.87). The difference is purely **whether the coordinator chose to pass `type=`**. This confirms the problem is behavioral, not a missing feature -- the feature exists but the coordinator doesn't reliably use it.
+
+---
+
+## Conclusions
+
+### 1. The `type=` parameter is the single point of failure
+
+The system works correctly when `type=` is passed. Identity.md is prepended. But coordinators don't reliably pass it. In Cluster2 (a full project-team workflow run with 11 agents), NONE of the spawns included `type=`.
+
+### 2. This is a guardrail problem, not a system bug
+
+The claudechic code at mcp.py lines 267-289 correctly handles identity injection. The `assemble_phase_prompt()` function works. The issue is that coordinators write freeform prompts and forget (or don't know) to include `type=`. A warn-level guardrail that fires when `spawn_agent` is called without `type=` during an active workflow would catch this.
+
+### 3. Phase file gap remains even with `type=` fixed
+
+The Skeptic has `specification.md`, `implementation.md`, and `testing.md` but NOT `leadership.md`. Since Leadership is the spawn phase, even with `type="skeptic"`, the Skeptic gets identity.md but NOT phase-specific instructions at spawn time. And when the workflow advances to specification/implementation/testing, there is NO broadcast to update the Skeptic with its new phase instructions.
+
+### 4. Non-standard agent names bypass the system entirely
+
+The Backend session used names like `SpecReviewer-Arch` that don't match any role folder. The `type=` parameter is the ONLY way to map arbitrary agent names to role folders. Without it, the fallback `agent_type or name` (mcp.py line 279) uses the agent name, which fails silently.
+
+### 5. Phase transition remains the critical unfixed gap
+
+Even in the current session (which correctly passes `type=`), advancing from leadership to specification would NOT update the Skeptic with `skeptic/specification.md`. The `advance_phase` code only updates the coordinator's `.claude/phase_context.md`.

--- a/.project_team/subagent_phase_injection/researcher_evidence_report.md
+++ b/.project_team/subagent_phase_injection/researcher_evidence_report.md
@@ -1,0 +1,266 @@
+# Evidence Report: Sub-Agent Phase Injection
+
+**Author:** Researcher agent
+**Date:** 2026-04-15
+**Issue:** #37
+**Method:** Source code tracing + runtime observation + session data analysis
+
+---
+
+## Executive Summary
+
+Sub-agents receive their `identity.md` content at spawn time (when `type=` is passed), but **receive ZERO automated phase updates during phase transitions**. The `advance_phase` code path only updates the coordinator's `.claude/phase_context.md` file. There is no iteration over sub-agents, no broadcast mechanism, and no system-level code that touches sub-agents during phase transitions.
+
+---
+
+## Task 1: spawn_agent Code Path
+
+**File:** `submodules/claudechic/claudechic/mcp.py`
+**Function:** `_make_spawn_agent()` (lines 159-298)
+
+### Parameters Accepted (lines 162-186)
+
+| Parameter | Type | Required | Purpose |
+|-----------|------|----------|---------|
+| `name` | string | Yes | Agent display name |
+| `path` | string | Yes | Working directory |
+| `prompt` | string | Yes | Initial prompt text |
+| `model` | string | No | Model override |
+| `type` | string | No | **Role name for guardrail env vars AND prompt assembly** |
+| `requires_answer` | boolean | No | Whether agent owes a reply |
+
+### What happens with `type` parameter (lines 198-227)
+
+When `type` is provided AND a workflow is active:
+1. **Validation** (lines 206-227): Checks that a folder `workflows/{workflow_id}/{type}/` exists. If not, returns an error listing available roles.
+2. **Model inheritance** (lines 229-235): If no explicit model, inherits caller's model.
+
+### How assemble_phase_prompt() is called (lines 267-289)
+
+```python
+# Line 268-269
+full_prompt = prompt
+if _app._workflow_engine:
+    # Lines 272-279
+    folder_prompt = assemble_phase_prompt(
+        workflows_dir=Path.cwd() / "workflows",
+        workflow_id=_app._workflow_engine.workflow_id,
+        role_name=agent_type or name,    # <-- CRITICAL: uses type param, falls back to name
+        current_phase=_app._workflow_engine.get_current_phase(),
+    )
+    if folder_prompt:
+        full_prompt = f"{folder_prompt}\n\n---\n\n{prompt}"
+```
+
+### What assemble_phase_prompt() does
+
+**File:** `submodules/claudechic/claudechic/workflows/agent_folders.py` (lines 80-102)
+
+Calls `_assemble_agent_prompt()` (lines 48-77) which:
+1. Looks for `workflows/{workflow_id}/{role_name}/identity.md` -- reads it if exists
+2. Looks for `workflows/{workflow_id}/{role_name}/{bare_phase}.md` -- reads it if exists
+3. Returns `"{identity}\n\n---\n\n{phase_content}"` if both exist, or just identity
+
+### The full_prompt sent to the sub-agent (line 283)
+
+```
+{identity.md content}
+
+---
+
+{phase.md content if it exists}
+
+---
+
+{coordinator's freeform prompt text}
+```
+
+Then wrapped by `_send_prompt_fire_and_forget()` (lines 138-156) with:
+```
+[Spawned by agent '{caller_name}']
+
+{full_prompt above}
+```
+
+### Key Finding: Spawn IS wired correctly (when type is passed)
+
+If the coordinator passes `type="researcher"` when spawning me, the system WILL prepend my `identity.md` + current phase `.md` (if it exists) to the coordinator's prompt. **This is the intended path and it works.**
+
+---
+
+## Task 2: advance_phase Code Path
+
+**File:** `submodules/claudechic/claudechic/mcp.py`
+**Function:** `_make_advance_phase()` (lines 793-878)
+
+### After successful phase transition (lines 835-872)
+
+```python
+if result.success:
+    # Lines 841-861: Build phase prompt for MAIN ROLE ONLY
+    phase_content = ""
+    main_role = getattr(engine.manifest, "main_role", None)
+    if main_role:
+        phase_content = assemble_phase_prompt(
+            workflows_dir=Path.cwd() / "workflows",
+            workflow_id=engine.workflow_id,
+            role_name=main_role,       # <-- ONLY the coordinator role
+            current_phase=next_phase,
+        )
+
+        # Line 865-867: Write to file for main agent
+        _app._inject_phase_prompt_to_main_agent(
+            engine.workflow_id, main_role, next_phase
+        )
+
+    # Lines 869-871: Return phase content inline to caller
+    response = f"Advanced to phase: {next_phase}"
+    if phase_content:
+        response += f"\n\n--- Phase Instructions ---\n\n{phase_content}"
+    return _text_response(response)
+```
+
+### What _inject_phase_prompt_to_main_agent does
+
+**File:** `submodules/claudechic/claudechic/app.py` (lines 1688-1700)
+
+```python
+def _inject_phase_prompt_to_main_agent(self, workflow_id, main_role, current_phase):
+    self._write_phase_context(workflow_id, main_role, current_phase)  # Writes .claude/phase_context.md
+    self._update_sidebar_workflow_info()                               # Updates UI sidebar
+```
+
+`_write_phase_context()` (lines 1702-1747) writes to `.claude/phase_context.md` which is read as a system prompt file by Claude Code on the next turn. **This only affects the main agent (coordinator).**
+
+### Is there ANY code that touches sub-agents during advance_phase?
+
+**NO.** I searched the entire `advance_phase` function, `_inject_phase_prompt_to_main_agent`, and `_write_phase_context`. There is:
+- No loop over `_app.agent_mgr` agents
+- No call to `_send_prompt_fire_and_forget` for sub-agents
+- No call to `assemble_phase_prompt` for any role other than `main_role`
+- No broadcast mechanism of any kind
+
+The comment on line 866 even says: "Still broadcast to OTHER agents asynchronously" -- but this is misleading. The function name `_inject_phase_prompt_to_main_agent` is accurate: it ONLY touches the main agent's context file.
+
+---
+
+## Task 3: Real Session Data
+
+### Available Data Sources
+
+| Source | Path | Content |
+|--------|------|---------|
+| Messages JSONL | `.project_team/audit_workflow/poc/gliclass/messages_310.jsonl` | 315 raw user messages from sessions |
+| Classification | `.project_team/audit_workflow/poc/gliclass/gliclass_results.jsonl` | ML classification of corrections |
+| Corrections Report | `corrections_report.json` | 27 sessions analyzed, 220 candidates |
+| Audit DBs | `scripts/audit/audit.db`, `scripts/audit/corrections.db` | Empty (0 bytes, initialized 2026-04-14) |
+
+### Evidence from corrections_report.json
+
+The corrections report documents sub-agent sessions where agents diverged from intent. Notably:
+- Session type "sub-agent" entries exist for agents like "Composability"
+- Corrections were detected when agents misunderstood architectural concepts
+- This confirms that sub-agents operate on whatever context the coordinator gave them, not on system-injected phase content
+
+### What the coordinator actually sends to sub-agents
+
+Based on the code path and the current session observation, the coordinator crafts a freeform prompt. If `type=` is passed, the system prepends `identity.md + phase.md`. If `type=` is NOT passed, the sub-agent gets ONLY the coordinator's freeform text.
+
+---
+
+## Task 4: Current Session Observation
+
+### What I (Researcher) actually received
+
+My initial prompt begins with:
+
+```
+[Spawned by agent 'AI_PROJECT_TEMPLATE']
+
+# Research Agent
+
+**Role: Research & Intelligence**
+...
+```
+
+This IS the content of `workflows/project_team/researcher/identity.md` (all 240 lines). This confirms that:
+1. The coordinator passed `type="researcher"` when spawning me
+2. `assemble_phase_prompt()` found my `identity.md` and prepended it
+3. The system IS working correctly for spawn-time injection
+
+### What phase file exists for researcher?
+
+```
+workflows/project_team/researcher/
+    identity.md   <-- EXISTS (12,243 bytes)
+    (no phase files)
+```
+
+The researcher role has NO phase-specific `.md` files (no `setup.md`, `leadership.md`, etc.). So even if the system DID broadcast phase updates to sub-agents, there would be nothing to inject for the researcher role. The same may be true for other non-coordinator roles.
+
+### What phase files exist for coordinator?
+
+```
+workflows/project_team/coordinator/
+    identity.md
+    vision.md
+    setup.md
+    leadership.md
+    specification.md
+    implementation.md
+    testing.md
+    signoff.md
+    documentation.md
+```
+
+The coordinator has a `.md` file for EVERY phase. This is the only role with per-phase content.
+
+### Current .claude/phase_context.md
+
+Contains the coordinator's identity.md + leadership.md content. Confirms the system updates this file for the coordinator only.
+
+---
+
+## Summary of Findings
+
+### What WORKS
+
+| Mechanism | Status | Evidence |
+|-----------|--------|----------|
+| `type=` parameter on spawn_agent | WORKS | Code lines 198-227, validated at runtime |
+| identity.md injection at spawn | WORKS | My own prompt contains full identity.md |
+| phase.md injection at spawn | WORKS (if file exists) | Code lines 272-283 |
+| Coordinator phase updates | WORKS | `.claude/phase_context.md` is written on advance |
+| PostCompact hook for re-injection | WORKS | `agent_folders.py` lines 105-147 |
+
+### What DOES NOT EXIST
+
+| Mechanism | Status | Evidence |
+|-----------|--------|----------|
+| Phase broadcast to sub-agents on advance | DOES NOT EXIST | No sub-agent iteration in advance_phase (lines 835-872) |
+| Phase-specific files for non-coordinator roles | MOSTLY ABSENT | researcher/ has only identity.md; need to check other roles |
+| Automatic re-injection of phase context to sub-agents | DOES NOT EXIST | PostCompact hook is per-agent but only fires on /compact |
+
+### The Two-Bug Problem
+
+**Bug A (spawn-time):** If coordinator forgets to pass `type=` parameter, the sub-agent gets NO role identity at all -- only the coordinator's freeform prompt. The system works correctly when `type=` is used, but there's no enforcement that it must be used.
+
+**Bug B (phase-transition):** Even if Bug A is fixed, there is NO mechanism to update running sub-agents when the workflow advances to a new phase. The system explicitly only updates `.claude/phase_context.md` for the main role. Sub-agents continue operating with whatever phase context they had at spawn time -- which for most non-coordinator roles is nothing, because phase-specific `.md` files don't exist for those roles.
+
+### Architectural Observation
+
+The current design seems intentional for a coordinator-centric model: the coordinator is the only agent that needs phase-by-phase instructions because it orchestrates the others. Sub-agents (Researcher, Skeptic, Composability, etc.) have role identities that are phase-invariant -- they do the same kind of work regardless of phase; only the coordinator's behavior changes per phase.
+
+The question for issue #37 is whether this is the RIGHT design, or whether sub-agents would benefit from phase-aware context (e.g., "in specification phase, focus on X; in implementation phase, focus on Y").
+
+---
+
+## Recommendations for the Team
+
+1. **Bug A is solvable with guardrails**: A `warn`-level rule on `spawn_agent` when `type` is missing and a workflow is active would catch coordinator mistakes.
+
+2. **Bug B requires a design decision**: Adding phase broadcast to sub-agents is a claudechic system change. But it only matters if sub-agent roles have phase-specific `.md` files. Currently they don't, so the broadcast would be a no-op.
+
+3. **The real fix may be workflow-level**: Create phase-specific `.md` files for key sub-agent roles (Skeptic, Composability, etc.) AND add broadcast on advance. Without both, neither alone is useful.
+
+4. **Phase file audit needed**: Check which sub-agent roles have phase-specific files vs. only identity.md to understand the scope of the gap.

--- a/.project_team/subagent_phase_injection/researcher_jsonl_analysis.md
+++ b/.project_team/subagent_phase_injection/researcher_jsonl_analysis.md
@@ -1,0 +1,264 @@
+# JSONL Analysis: What Skeptic Actually Received vs Phase Files
+
+**Author:** Researcher agent
+**Date:** 2026-04-15
+**Issue:** #37
+**Method:** Comparison of actual session data (corrections_report.json, test fixtures) against workflow phase files
+
+---
+
+## Executive Summary
+
+ALL historical Skeptic sessions in the audit data predate the current `type=` spawn mechanism. The coordinator manually told the Skeptic to "read your role file" from a filepath. The Skeptic never received its identity.md or phase files through the system -- it received coordinator-written freeform prompts that partially paraphrase the phase instructions but omit significant content.
+
+---
+
+## Data Sources
+
+| Source | Records | Skeptic Entries | Workflow Version |
+|--------|---------|-----------------|------------------|
+| `corrections_report.json` | 220 candidates, 27 sessions | 5 Skeptic sub-agent entries | `solo` or `ao_project_team` (both pre-current) |
+| `v2.1.59_subagent_session.jsonl` (test fixture) | 5 lines | 1 Skeptic spawn | Synthetic test data |
+| `.claude/hits.jsonl` | Guardrail hits | N/A | N/A |
+| Live session (current) | In progress | N/A | `project-team` (current) |
+
+**Critical context:** No sessions in corrections_report.json use `"workflow": "project-team"`. They use either `"solo"` or `"ao_project_team"` -- both predate the current agent_folders.py system with `type=` and `assemble_phase_prompt()`. This means ALL historical data shows the OLD behavior where the coordinator manually assembled prompts.
+
+---
+
+## Evidence Exhibit 1: Skeptic Spawn Prompt (2026-03-29, workflow "solo")
+
+### What the coordinator actually sent:
+
+```
+[Spawned by agent 'AI_PROJECT_TEMPLATE']
+
+You are Skeptic. Read your role file:
+/groups/spruston/home/moharb/AI_PROJECT_TEMPLATE/AI_agents/project_team/SKEPTIC.md.
+Project state:
+/groups/spruston/home/moharb/AI_PROJECT_TEMPLATE/.ao_project_team/composable_plugins/.
+Read /groups/spruston/home/moharb/AI_PROJECT_TEMPLATE/.ao_project_team/composable_plugins/userprompt.md
+for context.
+
+Phase task: Challenge assumptions in the vision. Key risks to evaluate:
+1. Is a plugin system over-engineering for 5 features? What's the minimum viable abstraction?
+2. "Lightweight" plugin system -- where's the line between too simple (just a convention)
+   and too complex (full plugin framework)?
+3. Onboarding UX -- web vs CLI vs Claude conversation: what are the real tradeoffs?
+4. Existing codebase integration -- what can actually go wrong when wrapping someone's
+   existing repo?
+5. The pattern miner depends on Claude session JSONL files -- is that a stable interface
+   to build on?
+
+Write findings to ...specification/skeptic_review.md. Report to: Coordinator
+```
+
+**Source:** `corrections_report.json` line 1984, session `d9587d98`
+
+### What the phase file says (specification.md):
+
+```markdown
+# Specification Phase
+
+1. Challenge assumptions in the vision
+2. Identify risks and failure modes
+3. Distinguish essential complexity (inherent to the problem) from accidental (poor design)
+4. Flag shortcuts disguised as simplicity
+5. Flag designs that introduce layers, abstractions, or multi-phase engines when a simpler
+   approach solves the same problem. If a proposal has more than 2 moving parts, ask: can
+   this be done with 1?
+6. Check for complexity carried over from previous spec revisions. When a spec is re-presented
+   after user feedback, verify that old complexity was actually removed -- not just shuffled.
+   Users simplify for a reason; do not let earlier over-engineering sneak back in
+7. Write findings to specification/skeptic_review.md
+8. Report to Coordinator
+```
+
+### Side-by-side comparison:
+
+| Phase File Instruction | Coordinator Sent? | Notes |
+|------------------------|-------------------|-------|
+| 1. Challenge assumptions in the vision | YES | Coordinator paraphrased as "Challenge assumptions in the vision" |
+| 2. Identify risks and failure modes | PARTIALLY | Coordinator listed specific risks instead of giving the general principle |
+| 3. Distinguish essential vs accidental complexity | **NO** | Completely omitted. This is a core Skeptic principle. |
+| 4. Flag shortcuts disguised as simplicity | **NO** | Completely omitted. |
+| 5. Flag over-engineered designs (>2 moving parts = too many) | **NO** | Completely omitted. Ironic given the project was about plugin systems. |
+| 6. Check for complexity from previous spec revisions | **NO** | Completely omitted. |
+| 7. Write findings to skeptic_review.md | YES | Coordinator gave full path |
+| 8. Report to Coordinator | YES | Coordinator said "Report to: Coordinator" |
+
+**Result: 4 of 8 instructions were omitted.** The coordinator sent project-specific questions instead of the phase file's general principles. The Skeptic missed the "distinguish essential vs accidental complexity" lens entirely.
+
+### What the Skeptic's identity.md says that was also missing:
+
+The coordinator told the Skeptic to `Read your role file: .../SKEPTIC.md` -- but this was from an older path (`AI_agents/project_team/SKEPTIC.md`), not the current workflow path. The Skeptic had to read it as a file, not receive it as injected context. Whether it actually read it depends on the Claude model's tool-calling behavior.
+
+---
+
+## Evidence Exhibit 2: Skeptic Implementation Review (2026-03-30, workflow "solo")
+
+### What the coordinator actually sent:
+
+```
+[Message from agent 'AI_PROJECT_TEMPLATE']
+
+Phase 4 implementation is code-complete. Review ALL implemented files for risks, bugs,
+and corner cases.
+
+Two implementers worked:
+[...detailed list of files and changes...]
+
+Please review ALL files. Check:
+1. Error handling -- does discovery never crash? Do tools return proper MCP error responses?
+2. Fork sync conflicts -- were they resolved correctly?
+3. Install scripts -- edge cases (pixi already installed, no git, no network)
+4. Copier conditionals -- do all combinations work?
+5. Security -- install scripts downloading from URLs, execution policy
+6. kwargs graceful degradation -- cluster_watch without send_notification
+
+Report your findings to Coordinator.
+```
+
+**Source:** `corrections_report.json` line 1969, session `d929dd27`
+
+### What the phase file says (implementation.md):
+
+```markdown
+# Implementation Phase
+
+Review Implementer code for:
+- Shortcuts that break functionality (edge cases ignored, burden shifted)
+- Unnecessary complexity (deep nesting, scattered responsibility, classes where functions suffice)
+- Verifiability -- can you see correctness by reading the code?
+
+Categorize issues as must-fix vs should-fix. Report to Coordinator.
+```
+
+### Side-by-side comparison:
+
+| Phase File Instruction | Coordinator Sent? | Notes |
+|------------------------|-------------------|-------|
+| Shortcuts that break functionality | PARTIALLY | Coordinator listed specific things to check, not the general principle |
+| Unnecessary complexity (deep nesting, scattered responsibility) | **NO** | Completely omitted |
+| Verifiability -- can you see correctness by reading? | **NO** | Completely omitted |
+| Categorize as must-fix vs should-fix | **NO** | Completely omitted |
+| Classes where functions suffice | **NO** | Completely omitted |
+
+**Result: The coordinator gave domain-specific review instructions but missed the Skeptic's core review lens.** The Skeptic was told WHAT to check but not HOW to evaluate it. The "verifiability" principle and the "must-fix vs should-fix" categorization framework were absent.
+
+---
+
+## Evidence Exhibit 3: Skeptic Debate Session (2026-03-30, workflow "solo")
+
+### What the coordinator sent:
+
+```
+Skeptic2 -- Composability2 has a different recommendation. Read their analysis and respond.
+
+[...Composability2's full position...]
+
+But you said `_skip_if_exists` avoids that entirely (Copier skips claudechic on updates).
+Does that invalidate their concern?
+
+Do you agree or disagree? Where is Composability2 wrong? Where are you wrong?
+Find the right answer together.
+
+Reply to Composability2 via tell_agent, CC me (tell Coordinator too).
+```
+
+**Source:** `corrections_report.json` line 1789
+
+### What any phase file says about this:
+
+**Nothing.** There is no Skeptic phase file for "debate" or "cross-agent review." The coordinator is improvising the Skeptic's instructions entirely. The Skeptic's identity.md does say "You CAN push for simpler approaches" and "Essential vs Accidental complexity" -- principles that ARE relevant here -- but the coordinator didn't reference them.
+
+---
+
+## Evidence Exhibit 4: Test Fixture (Synthetic Data)
+
+### The spawn in v2.1.59_subagent_session.jsonl:
+
+```json
+{
+  "type": "user",
+  "message": {
+    "content": "[Spawned by agent 'AI_PROJECT_TEMPLATE']\n\nYou are the **Skeptic**.
+    Review the implementation for correctness.\n\nPlease review scripts/data_loader.py
+    for potential issues."
+  }
+}
+```
+
+**This is synthetic test data**, but it reveals the expected pattern: a minimal spawn prompt with no identity.md injection. The Skeptic gets a one-line role description ("You are the Skeptic") instead of the 117-line identity.md.
+
+---
+
+## Evidence Exhibit 5: Current Session (Live, 2026-04-15)
+
+### What I (Researcher) actually received:
+
+My prompt begins with the FULL content of `workflows/project_team/researcher/identity.md` (240 lines / 12,243 bytes), followed by `---`, followed by the coordinator's task prompt.
+
+This confirms that in the CURRENT session (using the `project-team` workflow with the current claudechic version), `assemble_phase_prompt()` IS being called and IS prepending identity.md content.
+
+**But:** The researcher role has no phase-specific files, so there was nothing to inject beyond identity.md. If I had been spawned during a phase that has a `researcher/specification.md`, it would have been included.
+
+---
+
+## Phase File Audit: Which Roles Have Phase Files?
+
+| Role | identity.md | specification.md | implementation.md | testing.md | Other |
+|------|:-----------:|:-----------------:|:------------------:|:----------:|:-----:|
+| **coordinator** | YES | YES | YES | YES | vision, setup, leadership, signoff, documentation |
+| **skeptic** | YES | YES | YES | YES | -- |
+| **composability** | YES | YES | YES | -- | -- |
+| **implementer** | YES | -- | YES | YES | -- |
+| **researcher** | YES | -- | -- | -- | -- |
+| **lab_notebook** | YES | -- | -- | -- | -- |
+| **binary_portability** | YES | -- | -- | -- | -- |
+| **memory_layout** | YES | -- | -- | -- | -- |
+| **project_integrator** | YES | -- | -- | -- | -- |
+
+**Key finding:** The Skeptic is one of only 3 non-coordinator roles that HAS phase files. If the `type=` system works correctly (and it does in the current session), the Skeptic SHOULD receive its phase files at spawn time. The question is whether this actually happens in practice, and what happens at phase transitions.
+
+---
+
+## The Timeline Problem
+
+All historical Skeptic data is from `"workflow": "solo"` or `"workflow": "ao_project_team"` -- both predate the current system. The `type=` parameter and `assemble_phase_prompt()` were added later. This means:
+
+1. **No historical data exists for the current system.** We can't prove from JSONL data whether today's coordinator passes `type=` when spawning Skeptic.
+2. **The old behavior is well-documented:** coordinator manually told agents to read role files, paraphrased phase instructions, and frequently omitted key principles.
+3. **The new system CAN work** (proven by my own spawn in this session), but there's no evidence it's being used consistently for all roles.
+
+---
+
+## Conclusions
+
+### What the data proves:
+
+1. **Historical sessions (pre-current workflow): Skeptic received coordinator-written prompts that omitted 50-75% of phase file instructions.** The coordinator paraphrased some items, added project-specific context, but consistently missed general principles like "distinguish essential vs accidental complexity" and "categorize as must-fix vs should-fix."
+
+2. **The current system (assemble_phase_prompt + type=) would fix the spawn-time problem IF the coordinator passes type=.** My own session proves identity.md injection works.
+
+3. **Phase transitions remain completely unaddressed.** Even with the current system, when the workflow advances from "specification" to "implementation", a running Skeptic agent that was spawned during specification will still have `specification.md` content, not `implementation.md`. There is no mechanism to update it.
+
+4. **The Skeptic is one of the best-served roles** (has 3 phase files + identity.md). Most other sub-agent roles have only identity.md, making phase transitions irrelevant for them.
+
+### What the data does NOT prove:
+
+1. Whether the current coordinator actually passes `type=` when spawning Skeptic (no `project-team` workflow sessions exist in audit data yet).
+2. Whether the Skeptic actually read the role file when told to via filepath (old sessions). The corrections_report.json shows the Skeptic doing good work, suggesting it did read the file -- but we can't confirm programmatically.
+3. Whether the missing phase instructions (essential vs accidental complexity, etc.) actually caused measurable quality loss. The Skeptic debates in the data are sophisticated and well-reasoned despite the missing context.
+
+---
+
+## Recommendation
+
+The fix should address both layers:
+
+**Layer 1 (Guardrail):** Warn-level rule when `spawn_agent` is called without `type=` during an active workflow. This catches coordinator mistakes.
+
+**Layer 2 (System):** For the 3 roles that have phase files (skeptic, composability, implementer), add phase-transition broadcast in `advance_phase`. This requires iterating over `_app.agent_mgr` agents that have a known `agent_type`, calling `assemble_phase_prompt()` for each, and sending the new phase content via `_send_prompt_fire_and_forget()`.
+
+**Layer 3 (Content):** Audit whether more roles need phase files. Currently only coordinator, skeptic, composability, and implementer have them.

--- a/.project_team/subagent_phase_injection/skeptic_report.md
+++ b/.project_team/subagent_phase_injection/skeptic_report.md
@@ -1,0 +1,150 @@
+# Skeptic Report: Sub-agent Phase Injection (Issue #37)
+
+## TL;DR
+
+The issue description is **partially wrong**. spawn_agent DOES try to inject phase markdown at spawn time -- the code exists at mcp.py lines 268-289. But the injection is fragile and can silently fail. The real gap is **phase transitions**: when the workflow advances, sub-agents get nothing. Two separate problems, not one.
+
+---
+
+## Finding 1: spawn_agent Already Attempts Injection
+
+The issue says phase markdown is "never delivered." This is inaccurate. `mcp.py` `_make_spawn_agent` (line 268-289) does this:
+
+```python
+if _app._workflow_engine:
+    folder_prompt = assemble_phase_prompt(
+        workflows_dir=Path.cwd() / "workflows",
+        workflow_id=_app._workflow_engine.workflow_id,
+        role_name=agent_type or name,  # <-- KEY LINE
+        current_phase=_app._workflow_engine.get_current_phase(),
+    )
+    if folder_prompt:
+        full_prompt = f"{folder_prompt}\n\n---\n\n{prompt}"
+```
+
+**This code prepends identity.md + phase.md to the coordinator's prompt.** So if it works, the sub-agent DOES get phase context at spawn time.
+
+### Why it can fail silently
+
+1. **`agent_type or name` fallback**: If coordinator doesn't pass `type` param, `agent_type` is None, so it falls back to `name`. If the agent is named "Skeptic" but the folder is "skeptic", or "skeptic-agent" vs "skeptic" -- no match, silent None return.
+
+2. **Bare `except Exception` swallows errors** (line 286-289): Any failure in `assemble_phase_prompt` is caught, logged at DEBUG level, and ignored. The agent gets spawned without phase context and nobody knows.
+
+3. **No encoding param on `read_text()`** (agent_folders.py line 63, 73): `identity_path.read_text()` and `phase_path.read_text()` lack `encoding='utf-8'`. This is a cross-platform bug per CLAUDE.md rules and could cause failures on Windows.
+
+### Evidence assessment
+
+The JSONL analysis that found "skeptic/specification.md content never appears" is consistent with the coordinator not passing `type="skeptic"` on the spawn call. The code path exists but the coordinator doesn't know to use it -- the `type` parameter is undocumented in the coordinator's instructions and easy to omit.
+
+**Verdict: The injection mechanism exists but is unreliable. The issue should say "phase markdown injection is fragile and frequently fails" not "never delivered."**
+
+---
+
+## Finding 2: Phase Transitions Are Completely Unhandled for Sub-agents
+
+This is the **real bug**. When `advance_phase` runs (mcp.py line 793-878):
+
+1. Phase prompt is assembled for the **main_role only** (line 846-856)
+2. `_inject_phase_prompt_to_main_agent` writes `.claude/phase_context.md` -- which only the coordinator reads (line 865-866)
+3. There is NO mechanism to notify sub-agents of phase changes
+
+So even if a sub-agent was correctly injected at spawn, when the phase advances from "specification" to "implementation", the sub-agent stays on stale phase instructions forever (or until `/compact` triggers the PostCompact hook, which does re-inject -- but only for that agent's original role).
+
+**Verdict: This is a real gap. Sub-agents are spawn-and-forget with respect to phase transitions.**
+
+---
+
+## Finding 3: The `close_agent` Problem
+
+The STATUS.md mentions premature agent closure. Looking at `close_agent` (mcp.py line 602-644):
+
+- No guardrails prevent the coordinator from closing agents at any time
+- An agent cannot close itself (line 619) -- good
+- Cannot close the last agent (line 622) -- good
+- But there's no check for: "is this agent busy?", "has this agent completed its task?", "did we receive its output?"
+
+**Risk**: Coordinator spawns skeptic, skeptic starts working, coordinator gets impatient and closes it before results arrive. This is a behavioral problem, not a code bug -- guardrails could address it.
+
+**Verdict: Premature closure is real but behavioral. A `close_agent` guardrail warning is appropriate.**
+
+---
+
+## Risk Analysis of Fix Directions
+
+### Direction 1: Guardrail-only fix
+
+**What it does**: Warn coordinator to include phase markdown when spawning.
+
+**Risks**:
+- Coordinator can `acknowledge_warning` and ignore it -- the warning becomes noise
+- Doesn't fix the phase transition gap at all
+- Relies on the coordinator to correctly paraphrase phase content (the original problem)
+- Adds friction to every spawn call
+
+**Verdict: Insufficient as sole fix. Coordinator-authored prompts are the problem; a warning saying "include the content" still relies on the coordinator to do it right.**
+
+### Direction 2: claudechic auto-injection (strengthen existing code)
+
+**What it does**: Make spawn_agent injection reliable + add phase transition broadcasts.
+
+**Risks**:
+- **Double injection**: If the coordinator ALSO includes phase content in its prompt AND claudechic prepends it, the sub-agent gets duplicate instructions. The current code already prepends, so this is already a risk. Mitigation: document that claudechic handles injection, coordinator should not duplicate.
+- **Agent type mismatch**: If `type` doesn't match a folder name, validation already exists (mcp.py line 206-226) and returns an error. This is good.
+- **Utility agents without role folders**: If `type` is not provided, `agent_type` is None, and the code falls back to `name`. If no folder matches, `assemble_phase_prompt` returns None and no injection happens. **This is correct behavior** -- generic agents shouldn't get role context.
+- **Phase transition broadcast to busy agents**: Sending a phase update to an agent mid-task could confuse it. Should we interrupt or queue? `tell_agent` queues behind current work -- this is the safer choice.
+- **Stale agents**: An agent spawned in phase 1 that's still running in phase 3 gets broadcast for phase 2 and 3. Is that useful or confusing?
+
+**Verdict: Best direction, but needs careful design for phase transitions. The spawn-time fix is straightforward (make `type` param more prominent, fix encoding). Phase broadcast is more complex.**
+
+### Direction 3: Workflow-level fix
+
+**What it does**: Restructure project-team workflow to handle context delivery.
+
+**Risks**:
+- Only fixes one workflow, not the general mechanism
+- Puts the burden on workflow authors to solve a platform problem
+
+**Verdict: Wrong layer. This is a platform responsibility.**
+
+### Direction 4: Hybrid
+
+**What it does**: Auto-inject via claudechic + guardrail for close_agent.
+
+**Verdict: Best approach. claudechic handles the mechanical injection (it already tries to), guardrails handle the behavioral problems (premature closure).**
+
+---
+
+## Edge Cases to Watch
+
+1. **Agent spawned with no `type` and a name that happens to match a role folder**: Gets injection it didn't ask for. Low risk since the fallback `agent_type or name` is intentional, but could surprise.
+
+2. **Phase advances while sub-agent is being spawned**: Race condition between `advance_phase` and `spawn_agent`. The agent could get phase N instructions at spawn but phase N+1 is already active. The spawn code reads current phase from the engine, so this is a TOCTOU issue.
+
+3. **PostCompact hook assumes original role**: `create_post_compact_hook` captures `agent_role` at creation time. If an agent is somehow reassigned roles (not currently possible, but future-proofing), the hook would inject the wrong content.
+
+4. **`read_text()` without encoding**: Both calls in `agent_folders.py` (lines 63, 73) lack `encoding='utf-8'`. Per CLAUDE.md cross-platform rules, this WILL bite on Windows. Any fix must include this.
+
+5. **Coordinator prompt AFTER injection**: The current code prepends phase content, then appends the coordinator's prompt: `f"{folder_prompt}\n\n---\n\n{prompt}"`. The coordinator's prompt comes last, so if it contradicts the phase file, the coordinator wins (recency bias). This is arguably correct -- the coordinator adds context -- but could dilute phase instructions.
+
+---
+
+## Recommendations
+
+1. **Fix the encoding bug in agent_folders.py** -- trivial, no-risk, do it now
+2. **Make the existing spawn-time injection more robust** -- don't swallow exceptions silently, validate `type` param usage
+3. **Add phase transition broadcast to sub-agents** -- use `tell_agent` (queued, non-interrupting) to send new phase content
+4. **Add a `close_agent` guardrail** -- warn level, not deny, so coordinator can still close when appropriate
+5. **Do NOT add a `spawn_agent` guardrail for phase injection** -- the system should handle this automatically; warning the coordinator to do it manually is the wrong abstraction level
+6. **Document that `type` param is the role-folder link** -- this is currently implicit and easy to miss
+
+---
+
+## Summary Table
+
+| Claim in Issue #37 | Actually True? | Notes |
+|---|---|---|
+| "Phase markdown never delivered" | **Partially false** | Code exists at spawn time, but fragile |
+| "phase_context.md only for coordinator" | **True** | .claude/phase_context.md is coordinator-only |
+| "Sub-agents get coordinator-authored prompts" | **True but incomplete** | They get coordinator prompt WITH phase content prepended (when it works) |
+| "No mechanism for phase transitions" | **True** | Sub-agents get no updates on advance |
+| Premature closure risk | **Theoretical** | No evidence of actual premature closure, but no protection either |

--- a/.project_team/subagent_phase_injection/specification/skeptic_review.md
+++ b/.project_team/subagent_phase_injection/specification/skeptic_review.md
@@ -1,0 +1,126 @@
+# Skeptic Review: Proposed Fixes for Issue #37
+
+## Fix 1: Guardrail warn on spawn_agent without `type=` during active workflow
+
+### What can go wrong
+
+**Catch-22 risk: LOW but worth noting.** The guardrail triggers on `spawn_agent` when `type` is missing. The coordinator must acknowledge the warning and retry with `type=`. This is two tool calls instead of one, but NOT a catch-22 -- the guardrail doesn't block the operation it requires. It blocks spawn, telling you to add `type=`, then you retry with `type=` and pass. Clean.
+
+**False positives on utility agents.** Not every agent needs a role. A coordinator might spawn a "git-helper" agent to do a one-off task. This agent has no workflow role folder. The guardrail would fire a warning that's meaningless -- there IS no type to provide. The coordinator would have to acknowledge a warning for something that doesn't apply.
+
+**Mitigation:** The guardrail should only warn when role folders actually exist for the active workflow. Or: only warn when the workflow manifest declares sub-agent roles. If this becomes "always warn when type= is missing," it'll generate noise for legitimate utility agents.
+
+### Is there a simpler approach?
+
+Yes. Instead of a guardrail that warns and forces a retry, **claudechic could infer the role from the agent name as a fallback.** But this is fragile (name "Skeptic" vs folder "skeptic", name "skeptic-agent" vs folder "skeptic"). The current `agent_type or name` fallback already attempts this and it's what fails in practice.
+
+Better simple approach: **improve the spawn_agent tool description** to mention that `type` maps to role folders when a workflow is active. The LLM reads tool descriptions. If the description says "type: Agent role folder name. Required during active workflows for phase injection," the coordinator is far more likely to provide it. Zero code change, zero guardrail overhead.
+
+**Verdict: The guardrail is reasonable but the tool description improvement should come first. If that's insufficient, add the guardrail. Don't skip straight to enforcement.**
+
+---
+
+## Fix 2: Phase-transition broadcast on advance_phase
+
+### Critical prerequisite: Agent doesn't store its type
+
+**This is the biggest risk.** I checked `agent.py` -- the `Agent` class has NO `agent_type` field. The type is passed through `_make_options()` into `CLAUDE_AGENT_ROLE` env var and into `assemble_phase_prompt()` at spawn time, then discarded. After spawn, there is no way to look up which role an agent has.
+
+The phase broadcast needs to:
+1. Iterate all running agents
+2. For each typed agent, call `assemble_phase_prompt(role_name=agent.type, current_phase=new_phase)`
+3. Send the result via `_send_prompt_fire_and_forget`
+
+**Step 2 is impossible without storing the type on Agent.** This means the fix requires modifying `Agent.__init__` to accept and store `agent_type`, and modifying `AgentManager.create()` to pass it through. This is a larger change than it appears -- it touches the agent data model.
+
+### Fire-and-forget delivery risks
+
+`_send_prompt_fire_and_forget` creates an async task via `create_safe_task`. This means:
+
+1. **Message ordering is not guaranteed.** If the coordinator also sends instructions after advance_phase, the phase broadcast and coordinator message could arrive in either order. The sub-agent might get "work on implementation" from the coordinator BEFORE it gets the implementation.md phase content.
+
+2. **Agent might be busy.** If the sub-agent is mid-task when the broadcast arrives, it queues behind the current work. The agent finishes its old-phase task, THEN receives the new-phase context. This is actually fine -- `tell_agent` has the same behavior and it works.
+
+3. **Agent client might be None.** The `do_send()` function checks `agent.client is None` and silently skips. If an agent is in a transient disconnected state, the phase broadcast is silently lost. No retry, no error surfacing.
+
+4. **No delivery confirmation.** Fire-and-forget means we don't know if the agent received the message. If it fails, nobody knows. This is the same pattern as `tell_agent` so it's at least consistent, but for something as important as phase context, silent loss is concerning.
+
+### What if a phase file doesn't exist for a role in the new phase?
+
+`_assemble_agent_prompt` handles this gracefully (agent_folders.py line 66-73): if no `{phase}.md` file exists, `phase_content` stays empty and only `identity.md` is returned. If neither exists, empty string is returned, and `assemble_phase_prompt` converts that to `None` (line 102), so no broadcast is sent.
+
+**This is correct behavior.** A role without a phase file for the new phase just gets no broadcast. But there's a subtlety: the agent still has the OLD phase content in its context window. It doesn't get told "you're now in a new phase" -- it just doesn't get new instructions. The agent may continue operating on stale phase assumptions.
+
+**Mitigation:** Even when no phase file exists, send a minimal "Phase advanced to {new_phase}" notification so the agent at least knows the phase changed.
+
+### Double-injection risk
+
+The broadcast sends phase content as a chat message (via `_send_prompt_fire_and_forget`). The coordinator might ALSO tell the sub-agent "we've moved to implementation phase, here's what to do." Now the agent has:
+- Phase content from broadcast (system-generated)
+- Phase instructions from coordinator (human-authored)
+
+These could contradict. The coordinator's version is later in context, so LLM recency bias means the coordinator's paraphrase wins -- which is exactly the problem we're trying to fix.
+
+**Mitigation:** The broadcast message should be clearly marked as authoritative: "[Phase instructions from workflow system -- these are your primary instructions for this phase]". Or: send it as a system-level injection rather than a chat message if the SDK supports that.
+
+### What about closed/reopened agents?
+
+If an agent is closed and later reopened (`/agent reopen`), does it get phase broadcasts? Reopened agents aren't in the active agent list, so they'd miss transitions that happened while closed. The reopen path would need to re-inject current phase context.
+
+**Verdict: Fix 2 is the most important fix but also the most complex. Prerequisites: (a) store agent_type on Agent, (b) decide on delivery semantics (fire-and-forget is probably fine for now but document the limitation), (c) handle the "no phase file but phase changed" case, (d) address double-injection with clear message framing.**
+
+---
+
+## Fix 3: close_agent guardrail to prevent premature closure
+
+### What can go wrong
+
+**Catch-22 risk: NONE.** The guardrail warns on close_agent, coordinator acknowledges, closes anyway. No circular dependency.
+
+**But what does "premature" mean?** The guardrail needs a condition. Options:
+- Warn if agent status is BUSY -- reasonable, but the coordinator might have a good reason to close a stuck agent
+- Warn if agent has `_pending_reply_to` set -- means it owes someone an answer. Good signal.
+- Always warn -- noisy, coordinator has to acknowledge every close
+
+**Over-protection risk.** If the guardrail is too aggressive, coordinators learn to reflexively acknowledge it. The warning becomes invisible noise. This is worse than no guardrail because it gives false confidence ("we have protection") while providing none.
+
+### Is there a simpler approach?
+
+Instead of a guardrail, **`close_agent` could check if the agent has `_pending_reply_to` and include a warning in the response**: "Warning: this agent has an undelivered reply to {name}. Close anyway? (call close_agent again to confirm)." This is in-band, no guardrail infrastructure needed, and only fires when there's a real risk.
+
+**Verdict: A status-aware warning in close_agent itself is simpler and more precise than a guardrail rule. If a guardrail is used, it should be conditional on agent state (busy or has pending reply), NOT unconditional.**
+
+---
+
+## Fix 4: encoding='utf-8' in agent_folders.py
+
+### What can go wrong
+
+**Nothing.** This is a correctness fix per CLAUDE.md cross-platform rules. Two `read_text()` calls (lines 63, 73) need `encoding='utf-8'`. No behavioral change on Linux/Mac. Prevents `UnicodeDecodeError` on Windows when system encoding isn't UTF-8.
+
+### Edge cases
+
+None. The files are markdown, expected to be UTF-8.
+
+**Verdict: Do it. No risk. Should be included in any PR touching this file regardless of the other fixes.**
+
+---
+
+## Overall Assessment
+
+### Ordered by risk/reward
+
+| Fix | Risk | Reward | Complexity | Do it? |
+|-----|------|--------|------------|--------|
+| #4 encoding | None | Prevents Windows bugs | Trivial | Yes, immediately |
+| #1 spawn guardrail | False positives on utility agents | Better type= usage | Low | Start with tool description fix; guardrail if insufficient |
+| #3 close_agent | Over-protection noise | Prevents lost work | Low | Prefer in-band warning over guardrail |
+| #2 phase broadcast | Delivery ordering, data model change, double-injection | Fixes the real gap | Medium-High | Yes, but design carefully |
+
+### What's missing from the proposal
+
+1. **Agent.agent_type storage** -- prerequisite for Fix 2 that isn't mentioned
+2. **"Phase changed, no new instructions" notification** -- what happens when a role has no file for the new phase
+3. **PostCompact hook already exists for phase re-injection** -- does the broadcast interact with it? Could an agent get phase content from broadcast AND PostCompact if both trigger near a phase transition?
+4. **Test plan** -- how do we verify the broadcast works? The fire-and-forget pattern makes testing hard. Need to mock or capture the async tasks.
+5. **Tool description improvement** -- the simplest fix (update spawn_agent description to mention type=role mapping) isn't listed at all

--- a/.project_team/subagent_phase_injection/specification/terminology_review.md
+++ b/.project_team/subagent_phase_injection/specification/terminology_review.md
@@ -1,0 +1,231 @@
+# Terminology Review: SPEC.md (Issue #37)
+
+> Reviewed by Terminology Guardian against `terminology_report.md` glossary.
+> Spec file: `.project_team/subagent_phase_injection/SPEC.md`
+
+---
+
+## Overall Assessment
+
+The spec explicitly references the terminology report and uses canonical terms
+consistently throughout. Composability has done strong terminology work. I found
+**3 issues to fix**, **4 minor suggestions**, and **2 codebase convention
+concerns**. No blockers.
+
+---
+
+## Issues to Fix
+
+### 1. "agent prompt injection" (line 85) -- Overloaded Term
+
+**Quoted text (line 85):**
+> `"...Set type= to a role folder name to enable agent prompt injection."`
+
+**Problem:** "injection" is triple-overloaded per the glossary (filesystem
+injection, spawn-time injection, guardrails `Injection` dataclass). The warning
+message seen by the coordinator agent should not use bare "injection."
+
+**Fix:** Replace with:
+```
+"...Set type= to a role folder name so this agent receives its role-specific
+phase instructions at spawn and on phase transitions."
+```
+
+This avoids "injection" entirely in user-facing text and is clearer to the
+coordinator about *what* it's missing.
+
+---
+
+### 2. "roles" YAML field (line 253) vs Codebase Convention
+
+**Quoted text (line 253):**
+```yaml
+roles: [coordinator]
+```
+
+**Problem:** The existing `project_team.yaml` (line 57) already uses `roles:`
+and this is consistent. However, the terminology report's glossary and the
+existing `terminology.md` (line 76-78) document the field names as
+`block_roles` and `allow_roles`. The existing codebase uses bare `roles:` as
+shorthand for `block_roles:` (confirmed in `project_team.yaml` line 57).
+
+**This is fine** -- `roles:` is the actual YAML field name in the existing
+codebase. The `block_roles`/`allow_roles` distinction in `terminology.md` is
+the *conceptual* documentation. No change needed, but note the discrepancy
+for future terminology.md updates: the YAML field is `roles:` (equivalent to
+`block_roles`), and `allow_roles:` is the inverse. This should be documented
+in terminology.md.
+
+**Action:** No change to SPEC.md. Flag for terminology.md update:
+> "`roles:` in YAML is shorthand for `block_roles:`. The inverse is
+> `allow_roles:`. Both restrict which agent roles a rule applies to."
+
+---
+
+### 3. "Role type" in agent_manager.py Docstring (line 140 of agent_manager.py)
+
+**Quoted text (agent_manager.py line 140):**
+> `agent_type: Role type (e.g. "Implementer") -- injected as CLAUDE_AGENT_ROLE`
+
+**Problem:** The glossary says DO NOT USE "role type" (listed as redundant).
+The canonical term is **role**. Also, the example `"Implementer"` uses
+TitleCase, but all role folder names are lowercase (`implementer`, `skeptic`,
+`coordinator`). This is a pre-existing issue but the spec should note it
+for the implementer to fix alongside the `agent_type` storage change.
+
+**Recommended fix for agent_manager.py docstring:**
+```python
+agent_type: Agent's role name (e.g. "implementer") -- matches the role
+    folder under workflows/{workflow}/ and is set as CLAUDE_AGENT_ROLE env var.
+```
+
+---
+
+## Minor Suggestions
+
+### A. "typed sub-agents" (line 153 comment) -- Acceptable but Could Be Clearer
+
+**Quoted text (line 153):**
+```python
+# Broadcast phase update to all typed sub-agents
+```
+
+**Assessment:** "typed" means "has `agent_type` set." This is clear in context
+but could be misread as "statically typed" or "type-annotated." Consider:
+```python
+# Broadcast phase update to all sub-agents that have a role
+```
+
+This uses the canonical "role" term directly.
+
+---
+
+### B. "agent prompt" vs "phase instructions" -- Slight Inconsistency
+
+The spec uses both:
+- Line 178: `"Your updated phase instructions:\n\n"` (in broadcast message)
+- Line 11: "agent prompt (assembled identity file + phase file)"
+
+The broadcast message says "phase instructions" but what's delivered is the
+full **agent prompt** (identity + phase file). For a sub-agent receiving this
+mid-conversation, "phase instructions" is arguably more intuitive than "agent
+prompt" (which sounds like a system prompt). **This is acceptable** -- the
+broadcast message is a user-facing chat message, not a technical document.
+The spec's terminology header correctly defines "agent prompt" for technical
+use.
+
+**No change needed.** Just noting the intentional distinction between
+technical terminology (spec text) and agent-facing language (chat messages).
+
+---
+
+### C. "exclude_phases" (line 271) vs "exclude_phases" in Existing Rules
+
+**Quoted text (line 271):**
+```yaml
+exclude_phases: [signoff]
+```
+
+**Existing usage (project_team.yaml line 65):**
+```yaml
+exclude_phases: [testing, documentation, signoff]
+```
+
+**Assessment:** Consistent. The field name `exclude_phases` matches the
+existing codebase convention. Good.
+
+---
+
+### D. Comment in Code: "agent prompt" Variable Named `folder_prompt`
+
+**Quoted text (line 168):**
+```python
+agent_prompt = assemble_phase_prompt(...)
+```
+
+**Assessment:** Excellent. The spec correctly uses `agent_prompt` as the
+variable name (matching the glossary), unlike the existing `mcp.py` which
+uses `folder_prompt` (line 276). The implementer should also rename the
+existing `folder_prompt` in `spawn_agent` to `agent_prompt` for consistency.
+
+**Recommendation for implementer:** When modifying `mcp.py`, also rename
+`folder_prompt` (line 276) to `agent_prompt` in `spawn_agent`.
+
+---
+
+## Codebase Convention Verification
+
+### Rule ID Naming
+
+| Proposed Rule ID | Convention Check | Verdict |
+|---|---|---|
+| `spawn_agent_requires_type` | snake_case, descriptive, matches `no_direct_code_coordinator`, `no_push_before_testing`, `no_force_push` pattern | OK -- but existing IDs use `no_` prefix for prohibitions. This rule is a requirement, not a prohibition. `spawn_agent_requires_type` is appropriate for a "must do X" rule. |
+| `no_close_leadership` | `no_` prefix + snake_case, matches existing `no_force_push`, `no_push_before_testing` | OK |
+
+### YAML Field Names
+
+| Field | Matches Existing? | Verdict |
+|---|---|---|
+| `trigger: PreToolUse/mcp__chic__spawn_agent` | Yes -- existing rules use `PreToolUse/Bash`, `PreToolUse/Write` | OK |
+| `enforcement: warn` | Yes -- existing `warn_sudo` uses `warn` | OK |
+| `detect.pattern` + `detect.field` | Yes -- existing rules use `detect.pattern` | OK |
+| `roles: [coordinator]` | Yes -- line 57 of existing project_team.yaml | OK |
+| `exclude_phases: [signoff]` | Yes -- line 65 of existing project_team.yaml | OK |
+
+### Function/Method Names
+
+| Proposed | Convention Check | Verdict |
+|---|---|---|
+| `Agent.agent_type` attribute | Matches `Agent.worktree` pattern (optional metadata stored on instance). Not a property, just an attribute. | OK |
+| `_send_prompt_fire_and_forget` (reused) | Already exists in mcp.py | OK |
+| `assemble_phase_prompt` (reused) | Already exists in agent_folders.py | OK |
+
+### `__raw__` Pseudo-Field (line 56)
+
+The spec proposes `field: __raw__` for JSON-serialized tool input matching.
+**This does not exist in the current codebase.** The `detect.field` currently
+only supports named fields from tool input (e.g., `command` for Bash). The
+spec correctly identifies this as a problem and recommends the code-level
+warning approach instead (lines 76-89). Good self-correction. If the guardrail
+approach is pursued later, `__raw__` would need to be implemented in the
+detect matching logic.
+
+---
+
+## Summary of Required Actions
+
+| # | Severity | Location | Action |
+|---|---|---|---|
+| 1 | Fix | SPEC.md line 85 | Replace "agent prompt injection" with non-overloaded phrasing |
+| 2 | Note | terminology.md | Document that YAML `roles:` = `block_roles` shorthand |
+| 3 | Fix | SPEC.md / agent_manager.py | Change "Role type" to "role" in docstring; fix "Implementer" -> "implementer" |
+| A | Suggestion | SPEC.md line 153 | "typed sub-agents" -> "sub-agents that have a role" |
+| D | Suggestion | Implementation note | Rename existing `folder_prompt` -> `agent_prompt` in spawn_agent |
+
+---
+
+## Newcomer Simulation
+
+Reading the spec as a newcomer who has NOT read the terminology report:
+
+1. **Line 7-11 (terminology header):** Excellent. Defines key terms upfront with
+   a reference to the full glossary. A newcomer knows exactly where to look.
+
+2. **"spawn prompt" (line 10):** Defined in the header. Clear.
+
+3. **"in-band delivery" (line 108):** Used without inline definition. The
+   terminology report defines it, but a newcomer reading only the spec might
+   not know this means "via chat message." Consider adding "(via chat message)"
+   parenthetically on first use.
+
+4. **"fire-and-forget" (line 108, 389):** Used as an implementation detail.
+   Clear enough from context (non-blocking send), but the terminology report's
+   warning about conflating implementation pattern with communication semantics
+   is relevant here.
+
+5. **"PostCompact re-injection" (line 228, 395):** A newcomer might not know
+   what `/compact` is. The spec doesn't explain it, but this is appropriate --
+   the spec is for the implementation team, not end users.
+
+**Verdict:** Accessible to a contributor who reads the terminology header and
+follows the glossary link. No blockers for the target audience.

--- a/.project_team/subagent_phase_injection/specification/test_terminology_review.md
+++ b/.project_team/subagent_phase_injection/specification/test_terminology_review.md
@@ -1,0 +1,189 @@
+# Terminology Review: test_phase_injection.py
+
+> Reviewed by Terminology Guardian against `terminology_report.md` glossary.
+> File: `submodules/claudechic/tests/test_phase_injection.py`
+
+---
+
+## Overall Assessment
+
+The test file is well-written and largely consistent with the glossary. The
+module docstring (line 1) correctly uses "sub-agent phase injection" (hyphenated).
+Most test names and docstrings use canonical terms. Found **3 issues to fix**
+and **3 minor suggestions**.
+
+---
+
+## Issues to Fix
+
+### 1. "typed sub-agents" / "typed subagent" -- Non-Canonical Compound
+
+**Line 335 (test name):**
+```python
+async def test_typed_subagent_receives_broadcast_on_advance(
+```
+
+**Line 338 (docstring):**
+```python
+"""After advance_phase, typed sub-agents SHOULD receive phase broadcast."""
+```
+
+**Problems:**
+- `test_typed_subagent` -- "subagent" without hyphen. The glossary says use
+  **sub-agent** (hyphenated) for claudechic agents. Python identifiers can't
+  have hyphens, so `sub_agent` (with underscore) is the correct code form.
+- "typed sub-agents" -- "typed" means "has `agent_type` set," which is an
+  implementation detail. Per the SPEC.md review, prefer "sub-agents that have
+  a role."
+
+**Fix test name:**
+```python
+async def test_sub_agent_receives_broadcast_on_advance(
+```
+
+**Fix docstring:**
+```python
+"""After advance_phase, sub-agents with a role SHOULD receive phase broadcast."""
+```
+
+---
+
+### 2. "phase broadcast" / "phase content" -- Not in Glossary
+
+**Lines 328-329 (section comment):**
+```python
+# DESIRED: After advance_phase, typed sub-agents receive their
+#          role-specific phase content for the new phase.
+```
+
+**Lines 383-384, 386-387, 390-391, 393-394 (assertions):**
+```python
+"Skeptic (agent_type='skeptic') should receive phase broadcast"
+"Skeptic's broadcast should contain its implementation.md content"
+"Implementer (agent_type='implementer') should receive phase broadcast"
+"Implementer's broadcast should contain its implementation.md content"
+```
+
+**Problem:** "phase broadcast" and "phase content" are not defined in the
+glossary. The glossary defines the mechanism as **in-band delivery** and
+the content as the **agent prompt** (identity file + phase file).
+
+The SPEC.md (Fix 2) calls this a "Phase-Transition Broadcast" which is
+descriptive but not a glossary term. For test code, "broadcast" is acceptable
+as a *description* of what happens (sending to all sub-agents), but "phase
+content" should be "agent prompt" to match the glossary.
+
+**Fix section comment:**
+```python
+# DESIRED: After advance_phase, sub-agents with a role receive their
+#          role-specific agent prompt for the new phase.
+```
+
+**Fix assertion messages:**
+```python
+"Skeptic (agent_type='skeptic') should receive agent prompt on phase advance"
+"Skeptic's agent prompt should contain its implementation.md content"
+"Implementer (agent_type='implementer') should receive agent prompt on phase advance"
+"Implementer's agent prompt should contain its implementation.md content"
+```
+
+---
+
+### 3. "prompt assembly" (line 529-530) -- Vague
+
+**Lines 529-530 (section comment):**
+```python
+# DESIRED: spawn_agent uses ONLY agent_type (not `agent_type or name`)
+#          for role lookup. When type= is None, skip prompt assembly.
+```
+
+**Problem:** "prompt assembly" is ambiguous -- assembly of what? The glossary
+term is **agent prompt** and the function is `assemble_phase_prompt`. Should be:
+
+**Fix:**
+```python
+# DESIRED: spawn_agent uses ONLY agent_type (not `agent_type or name`)
+#          for role lookup. When type= is None, skip agent prompt assembly.
+```
+
+Small change -- just adding "agent" before "prompt assembly."
+
+---
+
+## Minor Suggestions
+
+### A. `_FakeAgent.agent_type` Conditional Storage (line 85-86)
+
+```python
+if agent_type is not None:
+    self.agent_type = agent_type
+```
+
+**Observation:** This conditionally sets `agent_type` only when not None,
+meaning `hasattr(agent, 'agent_type')` returns False for agents without a
+type. This is intentional (testing that the real Agent doesn't have the
+attribute yet), but after the fix, the real `Agent` will always have
+`agent_type` (defaulting to `None`). The fake should match:
+
+```python
+self.agent_type = agent_type  # Always set, default None in signature
+```
+
+This isn't a terminology issue but it affects test correctness post-fix.
+
+---
+
+### B. "role-specific phase content" (line 329) vs "agent prompt"
+
+The section header comment uses "role-specific phase content." Per glossary,
+the content delivered is the **agent prompt** (identity file + phase file).
+"Phase content" could be confused with **phase context** (the coordinator's
+`.claude/phase_context.md`).
+
+Already covered in Issue #2 above.
+
+---
+
+### C. Helper Docstring: "agent folder prompt" Risk
+
+**Line 42 (helper docstring):**
+```python
+"""Create a minimal workflow directory structure."""
+```
+
+This is fine -- no terminology issues. Just noting that the helper creates
+agent folders with phase files, and correctly uses "roles" as the parameter
+name (matching the glossary).
+
+---
+
+## Term-by-Term Audit
+
+| Term Used in Test File | Glossary Status | Verdict |
+|---|---|---|
+| "sub-agent" (line 1, module docstring) | Canonical | OK |
+| "subagent" (line 335, test name) | DO NOT USE | **Fix: use `sub_agent`** |
+| "sub-agents" (line 338, docstring) | Canonical | OK |
+| "agent_type" (throughout) | Acceptable as code identifier | OK (maps to "role" conceptually) |
+| "phase broadcast" (lines 383, 390) | Not in glossary | **Fix: "agent prompt on phase advance"** |
+| "phase content" (line 329) | Not in glossary, confusable with "phase context" | **Fix: "agent prompt"** |
+| "prompt assembly" (line 530) | Vague | **Fix: "agent prompt assembly"** |
+| "identity.md" (throughout) | Canonical ("identity file") | OK |
+| "specification.md" / "implementation.md" (throughout) | Canonical ("phase file") | OK |
+| "role" (lines 448, 541) | Canonical | OK |
+| "coordinator" (throughout) | Canonical | OK |
+| "spawn_agent" (throughout) | Tool name, not terminology | OK |
+| "advance_phase" (throughout) | Tool name, not terminology | OK |
+| "encoding='utf-8'" (throughout) | Cross-platform rule | OK |
+| "Agent.agent_type" (lines 259-273) | Acceptable as attribute name | OK |
+
+---
+
+## Summary of Required Actions
+
+| # | Severity | Line(s) | Action |
+|---|---|---|---|
+| 1 | Fix | 335, 338 | Rename `test_typed_subagent_*` to `test_sub_agent_*`; update docstring |
+| 2 | Fix | 329, 383-394 | Replace "phase content"/"phase broadcast" with "agent prompt" |
+| 3 | Fix | 530 | "prompt assembly" -> "agent prompt assembly" |
+| A | Suggestion | 85-86 | Make `_FakeAgent.agent_type` unconditional (always set, default None) |

--- a/.project_team/subagent_phase_injection/specification/useralignment_review.md
+++ b/.project_team/subagent_phase_injection/specification/useralignment_review.md
@@ -1,0 +1,116 @@
+# User Alignment Review -- Specification Phase
+
+## User Requirements Checklist
+
+Extracted from userprompt.md + user's in-session clarifications:
+
+| # | User Requirement | Source |
+|---|-----------------|--------|
+| R1 | Investigate what's actually happening -- don't assume | userprompt.md: "The team should investigate what's actually happening" |
+| R2 | Sub-agents should receive role-specific phase instructions (identity.md + {phase}.md) | userprompt.md: "Sub-agents spawned during workflow phases don't receive their role-specific phase instructions" |
+| R3 | Phase transitions need automated context injection to sub-agents | userprompt.md: "no automated way to inject updated context to sub-agents during phase transitions" |
+| R4 | Prevent coordinator from closing agents when it shouldn't | userprompt.md: "prevent coordinator from closing agents when it shouldn't" |
+| R5 | Propose fixes at ANY layer (guardrails, claudechic, workflow, or hybrid) | userprompt.md: "propose fixes at whichever layer makes sense" |
+| R6 | Multiple fix options, not one prescribed solution | STATUS.md lists 5 directions; user wants team to suggest |
+| R7 | Sparse phase files are a SYMPTOM -- sub-agents SHOULD have phase-specific instructions | User in-session: "this is from the fact that skeptic is missing things" |
+
+---
+
+## Coverage Assessment: What the Spec MUST Include
+
+### [OK] R1 -- Investigation complete, findings are evidence-based
+
+The Researcher and Skeptic both traced actual code paths and produced evidence. Nobody assumed. The team discovered:
+- Spawn-time injection EXISTS but is fragile (depends on `type=` being passed)
+- Phase-transition broadcast DOES NOT EXIST
+- close_agent has minimal guards
+
+This is exactly the discovery-first approach the user wanted.
+
+### [WARNING] R2 -- Spec must not downplay spawn-time injection
+
+The Skeptic correctly notes spawn-time injection "exists but is fragile." However, the user's original framing was: "The coordinator sends something, but not the actual phase files." The spec must address making spawn-time injection **reliable**, not just acknowledge it exists. Specifically:
+
+- The `type=` parameter must be prominently documented or enforced (guardrail warn if missing)
+- The silent `except Exception` swallowing must be fixed
+- The `encoding='utf-8'` cross-platform bug must be fixed
+
+The Skeptic's recommendation #5 says "Do NOT add a spawn_agent guardrail for phase injection -- the system should handle this automatically." This is a reasonable position IF the system fix is reliable. But the user originally asked for "a guardrail warn on spawn without the right MD file context." **The user explicitly requested a guardrail here.** The spec should include it, even if the system fix makes it a belt-and-suspenders approach.
+
+```
+? USER ALIGNMENT: User said "guardrail warn on spawn without the right MD file context."
+Skeptic says "Do NOT add a spawn_agent guardrail."
+These directly conflict. User's explicit request takes priority.
+Recommend: Include the guardrail (warn level) as the user asked, even alongside system fixes.
+```
+
+### [OK] R3 -- Phase-transition broadcast is a clear gap, all agents agree
+
+Everyone confirms: `advance_phase` only updates the coordinator. The spec MUST include a mechanism for sub-agent notification. The Skeptic's suggestion of `tell_agent` (queued, non-interrupting) is a reasonable approach.
+
+### [WARNING] R4 -- close_agent guards must be specified concretely
+
+The user said "prevent coordinator from closing agents when it shouldn't." The Skeptic calls this "theoretical" and recommends a warn-level guardrail. This is fine as a starting point, but the spec needs to define **what "shouldn't" means**. Options the spec should evaluate:
+
+1. Warn when closing an agent that is currently busy (status != idle)
+2. Warn when closing an agent that hasn't reported back (has pending work)
+3. Warn when closing an agent during a phase where that role is active
+4. Deny closing agents that have `requires_answer` pending
+
+The spec should pick at least one concrete policy, not just "add a guardrail."
+
+### [OK] R5 -- Multi-layer approach is well-covered
+
+The Skeptic's hybrid recommendation (Direction 4: claudechic for mechanism + guardrails for behavior) correctly spans layers. The Researcher confirmed the architectural context. The spec should present this as the recommended approach while noting alternatives.
+
+### [WARNING] R6 -- Spec should present options, not just one recommendation
+
+The user wanted the team to "suggest how to handle it" with multiple options. The Skeptic's report DOES analyze 4 directions with pros/cons. The spec should preserve this multi-option presentation, not collapse to a single "this is what we'll do." Let the user choose.
+
+### [WARNING] R7 -- Phase file content is IN SCOPE, not deferred
+
+The user confirmed sparse phase files are a symptom. The spec must address this. Two options:
+
+**Option A: Include phase file creation in the spec scope.** Write phase files for key roles (at minimum: skeptic, user_alignment, implementer, test_engineer) for the most common phases (specification, implementation, testing).
+
+**Option B: Mechanism-only, with a "missing phase file" warning.** Fix the injection mechanism, and add a hint/warning when a sub-agent role has no phase file for the current phase. This makes the gap visible so it gets addressed organically.
+
+The user's reaction suggests Option A is closer to their intent -- they see missing files as the bug's consequence, implying they should be filled in. But Option B is defensible if the spec explains why. **The spec should present both and let the user decide.**
+
+---
+
+## Items NOT in User's Request (Scope Creep Watch)
+
+| Item | Risk | Assessment |
+|------|------|------------|
+| PostCompact hook improvements | Low | Mentioned by Researcher but not in user's request. Fine to note but shouldn't be a primary deliverable. |
+| Documenting `type` param for workflow authors | Low | Supportive of the fix, not scope creep. |
+| Encoding bug fix in agent_folders.py | Low | Trivial, cross-platform mandatory per CLAUDE.md. Include it. |
+| Phase broadcast to stale agents (spawned 2+ phases ago) | Medium | Edge case worth noting in spec but shouldn't drive design. |
+| Race condition (TOCTOU) between spawn and advance | Low | Skeptic correctly flagged. Note but don't over-engineer. |
+
+None of these are scope creep -- they're reasonable supporting work. No red flags here.
+
+---
+
+## Summary: Spec Readiness Checklist
+
+| Requirement | Covered? | Action Needed |
+|------------|----------|---------------|
+| R1: Investigation | YES | Findings are solid |
+| R2: Spawn-time injection fix | PARTIAL | Must include user's requested guardrail warn, not just system fix |
+| R3: Phase-transition broadcast | YES | Clear gap, clear fix direction |
+| R4: close_agent guards | PARTIAL | Must define concrete "when" policy, not just "add a guardrail" |
+| R5: Multi-layer approach | YES | Hybrid is well-justified |
+| R6: Multiple options | AT RISK | Spec must present options, not collapse to one |
+| R7: Phase file content | AT RISK | Must address content creation or visibility, not ignore |
+
+---
+
+## Recommendation
+
+The spec is on solid ground for the mechanism fixes (R2, R3, R5). The three areas needing attention before spec approval:
+
+1. **Include the spawn_agent guardrail the user asked for** -- even if the Skeptic disagrees, the user explicitly requested it
+2. **Define concrete close_agent policy** -- "warn level guardrail" is too vague; specify the trigger conditions
+3. **Address phase file content** -- present Option A (write them) and Option B (warn when missing) and let user choose

--- a/.project_team/subagent_phase_injection/specification/useralignment_test_review.md
+++ b/.project_team/subagent_phase_injection/specification/useralignment_test_review.md
@@ -1,0 +1,136 @@
+# User Alignment Review: Test File (test_phase_injection.py)
+
+## User Requirements Being Checked
+
+The coordinator relayed these user directives for testing:
+1. **TDD -- all tests written before code**
+2. **ZERO mocking -- no fake async or anything else**
+3. **All tests RED before any code is written**
+4. **Each issue should have a failing test**
+5. **Simulate TUI with workflow activation and phase advance**
+
+---
+
+## Assessment
+
+### 1. TDD -- Tests Written Before Code
+
+**[OK] ALIGNED.** The file header says "EVERY test asserts desired post-fix behavior and MUST FAIL before production code is written." Each test block has clear comments explaining why it should fail now:
+
+- Test 1: "FAILS: Current code has bare read_text() without encoding"
+- Test 3: "FAILS: Current code silently falls back to name"
+- Test 4: "FAILS: advance_phase has no broadcast loop"
+- Test 5: "FAILS: The rule doesn't exist in the YAML yet"
+- Test 6: "FAILS: Current code does exact path match"
+- Test 8: "FAILS: Current code has `agent_type or name` fallback"
+
+Every test describes the desired post-fix behavior and why it currently fails. This is proper TDD.
+
+### 2. ZERO Mocking -- The _FakeAgent/_FakeApp Question
+
+**[WARNING] POTENTIAL MISALIGNMENT.** The user said "no fake async or anything else." The test file contains:
+
+- `_FakeAgent` (lines 69-93) -- hand-written class with `async def send()` that captures messages
+- `_FakeAgentManager` (lines 96-129) -- hand-written class with `async def create()`
+- `_FakeApp` (lines 132-156) -- hand-written class wrapping a **real** WorkflowEngine
+
+The file header explicitly claims: "Zero mocking -- no unittest.mock, no MagicMock, no AsyncMock, no monkeypatch."
+
+**Analysis of what "zero mocking" means:**
+
+The file avoids `unittest.mock` entirely -- no `MagicMock`, `AsyncMock`, `patch`, or `monkeypatch`. That's one valid interpretation of "zero mocking."
+
+However, the user said "no fake async or **anything else**." These `_Fake*` classes ARE fakes. They're hand-written test doubles (stubs/fakes), not mocks in the unittest.mock sense, but they ARE synthetic stand-ins for real objects. `_FakeAgent.send()` is a fake async method. `_FakeApp._inject_phase_prompt_to_main_agent` is a no-op stub.
+
+**The question is: did the user mean:**
+- (A) "Don't use unittest.mock/MagicMock" -- the file satisfies this
+- (B) "Don't use ANY test doubles -- exercise only real objects" -- the file violates this
+
+**Context clue:** The SPEC itself (lines 390, 417) says "Mock agent_mgr.agents with typed agents" and "unit/mock tests." This suggests the SPEC was written before the user's "zero mocking" directive, and the test file is trying to reconcile them by using hand-written fakes instead of unittest.mock.
+
+**My assessment:** The hand-written fakes are a reasonable pragmatic compromise. Testing MCP handlers against the real TUI (Textual app, SDK connections) would require an integration test with a running claudechic instance, which is slow, fragile, and likely not what the user meant. The fakes use a **real WorkflowEngine** and **real file I/O** -- the core logic under test is exercised with real objects. Only the delivery mechanism (Agent.send) is stubbed.
+
+**However,** the user's words were "no fake async or anything else," and `_FakeAgent.send()` is literally fake async. If the user is strict about this, the tests need restructuring.
+
+```
+? USER ALIGNMENT: User said "ZERO mocking -- no fake async or anything else."
+The test file uses hand-written _FakeAgent with `async def send()` -- this IS fake async.
+It avoids unittest.mock entirely, but _FakeAgent/_FakeApp are still test doubles.
+Is this what the user intended to prohibit?
+Recommend: Ask user to clarify. If strict, tests need to use real Agent/App objects
+(much harder, likely requires integration test infrastructure).
+```
+
+### 3. All Tests RED Before Code
+
+**[OK] ALIGNED (with one caveat).** The tests are designed to fail against current code. However, I cannot verify they actually all fail right now without running them. Tests 2 and 7 check for `agent_type` on `Agent` -- if that attribute was already added as part of another change, they might pass. The file should be run to confirm all RED before any production changes.
+
+### 4. Each Issue Has a Failing Test
+
+**[OK] ALIGNED.** Coverage mapping:
+
+| Issue | Test(s) |
+|-------|---------|
+| encoding='utf-8' missing | Test 1 (`test_read_text_calls_have_encoding_param`) |
+| Agent.agent_type storage | Tests 2, 7 (`test_agent_accepts_agent_type_kwarg`, `test_agent_manager_passes_agent_type_to_agent`) |
+| spawn without type= silent failure | Tests 3, 8 (`test_spawn_without_type_emits_warning`, `test_spawn_agent_no_name_fallback`) |
+| Phase broadcast missing | Test 4 (`test_typed_subagent_receives_broadcast_on_advance`) |
+| close_agent unguarded | Test 5 (`test_close_leadership_rule_exists_in_manifest`) |
+| Case-insensitive role lookup | Test 6 (`test_mixed_case_role_finds_lowercase_folder`) |
+
+All issues from the spec have corresponding failing tests.
+
+**One gap:** No test for "sub-agents WITHOUT agent_type should NOT receive broadcast." The SPEC lists this as test case #4 (`test_broadcast_skips_untyped`), but it's not in the file. This is a **scope shrink** -- a spec-required test is missing.
+
+```
+[WARNING] USER ALIGNMENT: SPEC lists test_broadcast_skips_untyped (spec item #4)
+but the test file does not include it. This is a missing negative test --
+the broadcast must NOT spam untyped agents.
+```
+
+**Another gap:** No test for "broadcast skips coordinator" (SPEC item #3, `test_broadcast_skips_coordinator`). The coordinator should not receive a duplicate broadcast since it already gets phase content inline.
+
+```
+[WARNING] USER ALIGNMENT: SPEC lists test_broadcast_skips_coordinator (spec item #3)
+but the test file does not include it.
+```
+
+### 5. Simulate TUI with Workflow Activation and Phase Advance
+
+**? NEEDS CLARIFICATION.** The tests exercise MCP handler functions directly (`spawn_agent.handler({...})`, `advance.handler({})`), NOT the actual TUI. They:
+- Create a real WorkflowEngine with real phases
+- Create real workflow files on disk
+- Call MCP handlers that would normally be invoked by Claude through the TUI
+- Use `_FakeApp`/`_FakeAgentManager` instead of the real Textual app
+
+This is testing the **MCP layer** (where the bugs live), not the TUI layer. For the bugs in question, this is the correct test surface -- the TUI is just a wrapper around these MCP handlers.
+
+However, the user said "simulate TUI with workflow activation and phase advance." If they meant a full end-to-end test with the Textual app running, these tests don't do that. If they meant "test the same code path the TUI uses," these tests DO do that (MCP handlers are exactly what the TUI calls).
+
+```
+? USER ALIGNMENT: User said "simulate TUI with workflow activation and phase advance."
+Tests call MCP handlers directly (the layer where bugs live), not the Textual TUI.
+This tests the RIGHT code but not via the TUI path.
+Is this adequate, or does the user want actual TUI integration tests?
+Recommend: Clarify with user. MCP-level testing is more reliable and faster,
+but doesn't exercise the full TUI → MCP → Agent stack.
+```
+
+---
+
+## Summary
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| TDD (tests before code) | [OK] ALIGNED | All tests describe desired behavior + why they fail now |
+| Zero mocking | ? NEEDS CLARIFICATION | No unittest.mock, but uses hand-written _Fake* classes with fake async |
+| All tests RED | [OK] ALIGNED (unverified) | Designed to fail, should be run to confirm |
+| Each issue has test | [WARNING] 2 MISSING | `test_broadcast_skips_untyped` and `test_broadcast_skips_coordinator` from spec not included |
+| TUI simulation | ? NEEDS CLARIFICATION | Tests MCP handlers (correct layer) but not actual TUI |
+
+## Recommendations
+
+1. **Ask user about _Fake* classes** -- Are hand-written fakes acceptable if unittest.mock is avoided? This determines whether a major restructuring is needed.
+2. **Add the two missing tests** -- `test_broadcast_skips_untyped` and `test_broadcast_skips_coordinator` are in the spec and should be in the file.
+3. **Run the tests** to confirm they all fail (RED) before any production code changes.
+4. **Clarify "TUI simulation"** -- MCP-level testing is pragmatic and correct; full TUI testing is expensive and fragile. User should confirm which they want.

--- a/.project_team/subagent_phase_injection/terminology_report.md
+++ b/.project_team/subagent_phase_injection/terminology_report.md
@@ -1,0 +1,155 @@
+# Terminology Report: Sub-agent Phase Injection (Issue #37)
+
+> Produced by Terminology Guardian. Canonical reference for all naming
+> decisions in this issue. Other issue documents should reference, not
+> duplicate, these definitions.
+
+---
+
+## 1. Glossary of Canonical Terms
+
+### Agent Hierarchy
+
+| Canonical Term | Definition | DO NOT USE |
+|---|---|---|
+| **coordinator** | The main agent whose role matches `main_role` in the workflow manifest. Receives `phase_context.md` via the filesystem. | "main agent" (ambiguous with AgentManager's first agent), "parent agent" |
+| **sub-agent** | Any agent spawned by the coordinator (or by another sub-agent) via `spawn_agent`. Has its own chat view and SDK client. Hyphenated. | "child agent", "spawned agent" (too generic), "subagent" (no hyphen) |
+| **role** | The identity of an agent, derived from its agent folder name (e.g. `coordinator`, `implementer`, `skeptic`). Set via the `type` parameter of `spawn_agent`. | "role type" (redundant), "agent type" (overloaded -- `type` is the spawn parameter name) |
+
+**Note on "spawned agent":** The codebase uses "spawned agent" in test comments (`test_yolo_flag.py`) and `is_spawn=True` as an internal flag. These are acceptable as *descriptions* ("the agent that was spawned") but not as a *term*. The term is **sub-agent**.
+
+**Note on "subagent" vs "sub-agent":** Claude Code's SDK uses `subagent_type` (no hyphen) for the Task tool's built-in sub-agents. claudechic's multi-agent system is different -- these are full agents, not Task sub-agents. Use **sub-agent** (hyphenated) for claudechic agents to distinguish from SDK's `subagent` concept. The codebase already uses "sub-agent" in `corrections_report.json` (`session_type: "sub-agent"`) and STATUS.md.
+
+---
+
+### Prompt Assembly
+
+| Canonical Term | Definition | Code Location | DO NOT USE |
+|---|---|---|---|
+| **identity file** | `identity.md` in an agent folder. Cross-phase content, always loaded. | `agent_folders.py:61` | "identity prompt", "role prompt" |
+| **phase file** | `{phase}.md` in an agent folder (e.g. `specification.md`). Phase-specific instructions. Loaded only during that phase. | `agent_folders.py:67-73` | "phase markdown" (ambiguous), "phase instructions" (too vague), "phase prompt" (confusing with assembled result) |
+| **agent prompt** | The assembled result: identity file + phase file, concatenated with `---` separator. This is what the agent actually receives. | `agent_folders.py:48-77` (`_assemble_agent_prompt`) | "role prompt", "system prompt" (overloaded), "full prompt" |
+| **phase context** | The `phase_context.md` file written to `.claude/` for the coordinator only. Contains the agent prompt for the `main_role`. Read by Claude Code as part of the system prompt. | `app.py:1708-1736` (`_write_phase_context`) | "phase context file" (redundant -- "phase context" already implies the file) |
+
+**Critical distinction:** `phase_context.md` is the *coordinator's* delivery mechanism (filesystem). Sub-agents receive their agent prompt via `spawn_agent`'s prompt parameter (in-band). These are the same *content* but different *delivery paths*.
+
+---
+
+### Content Delivery Mechanisms
+
+| Canonical Term | Definition | Used For | Code Location |
+|---|---|---|---|
+| **filesystem injection** | Writing `phase_context.md` to `.claude/` so Claude Code reads it as system prompt context. | Coordinator only. | `app.py:1708` (`_write_phase_context`) |
+| **spawn-time injection** | Prepending the agent prompt to the spawn prompt before sending to a new sub-agent. | Sub-agents at creation. | `mcp.py:268-289` (in `spawn_agent`) |
+| **in-band delivery** | Sending content via `tell_agent` / `ask_agent` / `interrupt_agent` as a chat message. | Ad-hoc updates to running agents. | `mcp.py:118-156` (`_send_prompt_fire_and_forget`) |
+| **PostCompact re-injection** | A hook that re-assembles and re-injects the agent prompt after `/compact` discards context. | Any agent with a registered PostCompact hook. | `agent_folders.py:105-146` |
+
+**DO NOT USE:** "auto-injection" (ambiguous -- which mechanism?), "manual delivery" (vague), "push-based" vs "pull-based" (the spec's "pull-based" description is inaccurate -- spawn-time injection is push-based).
+
+---
+
+### Spawn Concepts
+
+| Canonical Term | Definition | DO NOT USE |
+|---|---|---|
+| **spawn prompt** | The `prompt` parameter passed to `spawn_agent`. This is the coordinator's task instructions for the sub-agent. | "initial prompt" (acceptable in comments but not as a term), "coordinator prompt" |
+| **full prompt** | Internal variable name (`full_prompt` in `mcp.py:269`). The spawn prompt with agent prompt prepended. Not a user-facing term. | -- |
+
+---
+
+### Communication Patterns
+
+| Canonical Term | Definition | Code Pattern |
+|---|---|---|
+| **fire-and-forget** | Sending a message without blocking the caller. The internal `_send_prompt_fire_and_forget` function. Used by `tell_agent`, `ask_agent`, and spawn-time injection. | `mcp.py:118-156` |
+| **ask (expect reply)** | `ask_agent` -- sends a question, recipient is nudged if idle without responding. | `mcp.py:346-378` |
+| **tell (no reply)** | `tell_agent` -- sends a message, no reply expected. | `mcp.py:381-409` |
+
+**Note:** "fire-and-forget" describes the *implementation* (non-blocking async task), not the *semantics*. `ask_agent` is fire-and-forget at the implementation level but semantically expects a reply. Do not conflate implementation pattern with communication semantics.
+
+---
+
+## 2. Synonyms Found
+
+| Variants Found | Where | Recommendation |
+|---|---|---|
+| "phase context" / "phase prompt" / "phase instructions" / "phase markdown" | STATUS.md, mcp.py comments, workflows-system.md, audit specs | **agent prompt** for the assembled content. **phase file** for `{phase}.md`. **phase context** only for `phase_context.md`. |
+| "sub-agent" / "child agent" / "spawned agent" / "subagent" | STATUS.md, test files, docs, corrections_report.json | **sub-agent** (hyphenated) everywhere. |
+| "role prompt" / "coordinator prompt" / "spawn prompt" | Not heavily used yet but at risk | **spawn prompt** for the `prompt` param. **agent prompt** for identity + phase. Never "role prompt". |
+| "folder prompt" / "agent folder prompt" | `mcp.py:276` (`folder_prompt` variable) | **agent prompt**. The variable `folder_prompt` in code is acceptable as a local name but should not leak into documentation. |
+
+---
+
+## 3. Overloaded Terms
+
+### "phase context"
+- **Meaning 1:** The `.claude/phase_context.md` file (coordinator only).
+- **Meaning 2:** The general concept of "context about the current phase" (used loosely in comments).
+- **Recommendation:** Reserve "phase context" exclusively for the `phase_context.md` file/mechanism. Use "agent prompt" for the assembled content, "phase file" for the source markdown.
+
+### "prompt"
+- **Meaning 1:** The `prompt` parameter of `spawn_agent` (task instructions from coordinator).
+- **Meaning 2:** The assembled agent prompt (identity + phase file).
+- **Meaning 3:** The full prompt (agent prompt + spawn prompt concatenated).
+- **Recommendation:** Always qualify: "spawn prompt", "agent prompt", or "full prompt". Never bare "prompt" in documentation.
+
+### "inject" / "injection"
+- **Meaning 1:** Writing `phase_context.md` (filesystem injection).
+- **Meaning 2:** Prepending agent prompt at spawn time (spawn-time injection).
+- **Meaning 3:** `Injection` dataclass in guardrails (YAML `injections:` section).
+- **Recommendation:** Always qualify with mechanism: "filesystem injection", "spawn-time injection", "PostCompact re-injection". The guardrails `Injection` is a separate concept entirely.
+
+---
+
+## 4. Orphan Definitions
+
+| Term Used | Where | Definition Status |
+|---|---|---|
+| `main_role` | `project_team.yaml:2`, `mcp.py:843` | Defined implicitly. **Add:** "The role name of the coordinator agent, declared in the workflow manifest." |
+| `agent_type` | `spawn_agent` parameter | Used as synonym for "role" in code. **Clarify:** `type` parameter maps to the agent's role (folder name). |
+| `full_prompt` | `mcp.py:269` | Local variable, no documentation. Acceptable as code-only. |
+| `folder_prompt` | `mcp.py:276` | Local variable, no documentation. Acceptable as code-only. |
+
+---
+
+## 5. Canonical Home Violations
+
+| Term | Duplicated In | Canonical Home | Action |
+|---|---|---|---|
+| Agent prompt assembly | `workflows-system.md:48`, `agent_folders.py` docstring, `terminology.md:170-171` | `terminology.md:170` (existing workflow guidance spec) | Other files should say "See terminology.md" or keep to one sentence. |
+| PostCompact hook | `workflows-system.md:48`, `agent_folders.py:105`, `terminology.md:186` | `agent_folders.py` (code is canonical) + `terminology.md:186` (definition) | OK -- code is source of truth, terminology.md is definition home. |
+
+---
+
+## 6. Newcomer Blockers
+
+### In STATUS.md (issue #37)
+- **"phase_context.md is assembled for the coordinator only"** -- A newcomer won't know what `phase_context.md` is or why it matters. Add: "the file at `.claude/phase_context.md` that delivers phase instructions via the system prompt."
+- **"Sub-agents receive coordinator-authored prompts, not their role phase files"** -- Conflates two problems. Clarify: sub-agents receive the coordinator's *spawn prompt* (task instructions) but not their own *agent prompt* (identity file + phase file).
+- **"No automated mechanism to inject context to running sub-agents on phase transition"** -- Which kind of injection? Clarify: no mechanism to deliver updated phase files to already-running sub-agents when `advance_phase` is called.
+
+### In mcp.py
+- **Line 276:** `folder_prompt` variable name -- if a newcomer reads this, "folder prompt" is not defined anywhere. The variable assembles the agent prompt from the agent folder. Acceptable as internal code but should not appear in docs or comments to users.
+
+---
+
+## 7. The Core Issue #37 in Canonical Terms
+
+Restated with consistent terminology:
+
+1. **At spawn time:** The coordinator sends sub-agents a **spawn prompt** (task instructions). `spawn_agent` correctly prepends the sub-agent's **agent prompt** (identity file + phase file) via **spawn-time injection** (`mcp.py:268-289`). This works.
+
+2. **At phase transition:** When `advance_phase` runs, the coordinator's **phase context** (`phase_context.md`) is updated via **filesystem injection**. But there is no mechanism to deliver updated **phase files** to already-running sub-agents. They keep operating under stale phase instructions.
+
+3. **After compaction:** The **PostCompact re-injection** hook exists and works for agents that have one registered. But sub-agents may not have this hook if they were spawned without a `type` parameter.
+
+---
+
+## 8. Terms That Are Fine As-Is
+
+These terms are used consistently and do not need changes:
+
+- **workflow**, **manifest**, **phase**, **advance checks** -- well-defined in existing `terminology.md`
+- **`ask_agent`**, **`tell_agent`**, **`spawn_agent`** -- tool names, not ambiguous
+- **agent folder** -- defined in `terminology.md:158`, used consistently
+- **rule**, **hint**, **check** -- distinct mechanisms, well-documented

--- a/.project_team/subagent_phase_injection/useralignment_report.md
+++ b/.project_team/subagent_phase_injection/useralignment_report.md
@@ -1,0 +1,120 @@
+# User Alignment Report -- Issue #37: Sub-agent Phase Markdown Not Injected
+
+## Original Request Summary
+
+From userprompt.md:
+1. **"Sub-agents spawned during workflow phases don't receive their role-specific phase instructions (identity.md + {phase}.md)"**
+2. **"The coordinator sends something, but not the actual phase files"**
+3. **"There is no automated way to inject updated context to sub-agents during phase transitions"**
+4. **"Prevent coordinator from closing agents when it shouldn't"**
+5. **"The team should investigate what's actually happening and propose fixes at whichever layer makes sense (guardrails, claudechic, workflow, or hybrid)"**
+
+## Investigation Findings
+
+### Finding 1: spawn_agent DOES inject phase markdown at spawn time
+
+Contrary to the issue title, `spawn_agent` in mcp.py (lines 267-289) **already has code to inject role phase files**:
+
+```python
+if _app._workflow_engine:
+    folder_prompt = assemble_phase_prompt(
+        workflows_dir=Path.cwd() / "workflows",
+        workflow_id=_app._workflow_engine.workflow_id,
+        role_name=agent_type or name,
+        current_phase=_app._workflow_engine.get_current_phase(),
+    )
+    if folder_prompt:
+        full_prompt = f"{folder_prompt}\n\n---\n\n{prompt}"
+```
+
+**Critical detail:** This uses `agent_type or name` as the role lookup. If the coordinator spawns an agent with `type="user_alignment"`, the system reads `workflows/project_team/user_alignment/identity.md` + the current phase `.md`. If `type` is not provided, it falls back to the agent `name`, which may not match a role folder.
+
+**So the real question is:** Does the coordinator actually pass `type=` when spawning? If it writes the spawn prompt itself (which it does -- the prompt is freeform text), the coordinator controls what `type` gets set to.
+
+### Finding 2: Phase transitions DO NOT notify sub-agents
+
+The `advance_phase` function (mcp.py lines 793-878) only injects phase context to the **main agent** (coordinator):
+- Line 865: `_app._inject_phase_prompt_to_main_agent(...)` -- writes to `.claude/phase_context.md`
+- This only updates the coordinator's context file
+- **No mechanism exists to notify running sub-agents that the phase changed**
+- Sub-agents spawned in phase N continue with phase N context even after advancing to phase N+1
+
+This confirms the user's statement: **"there is no automated way to inject updated context to sub-agents during phase transitions."**
+
+### Finding 3: close_agent has minimal guards
+
+The `close_agent` function (mcp.py lines 602-643) has only two restrictions:
+1. An agent cannot close itself (`name == caller_name`)
+2. Cannot close the last agent (`len(agent_mgr) <= 1`)
+
+**No other controls exist.** Any agent (including the coordinator) can close any other agent at any time. There are no:
+- Phase-based restrictions (e.g., "don't close during active work")
+- Role-based restrictions (e.g., "coordinator can't close leadership agents")
+- Confirmation requirements
+- Guardrail rules on close_agent
+
+This confirms the user's concern about the coordinator closing agents when it shouldn't.
+
+### Finding 4: Most roles lack phase-specific markdown
+
+Phase coverage across roles (workflow has 8 phases: vision, setup, leadership, specification, implementation, testing, documentation, signoff):
+
+| Role | Phase files | Coverage |
+|------|------------|----------|
+| coordinator | 8 of 8 | Full |
+| skeptic | 3 (impl, spec, testing) | Partial |
+| implementer | 2 (impl, testing) | Partial |
+| user_alignment | 1 (specification) | Minimal |
+| composability | 2 (impl, spec) | Partial |
+| terminology | 1 (specification) | Minimal |
+| researcher | 0 | identity.md only |
+| test_engineer | 0 | identity.md only |
+| ui_designer | 0 | identity.md only |
+| lab_notebook | 0 | identity.md only |
+| others | 0 | identity.md only |
+
+Even if injection works, **most roles have no phase markdown to inject**. This is a content gap alongside the mechanism gap.
+
+## Alignment Status
+
+### [OK] ALIGNED: Discovery-first approach
+
+The user said **"investigate what's actually happening"** -- team should NOT assume the system is broken. In fact, spawn-time injection code exists. The real issues are:
+1. Whether the coordinator actually uses `type=` correctly when spawning
+2. Phase transition notification is missing for sub-agents
+3. close_agent is unrestricted
+4. Phase file content is sparse for non-coordinator roles
+
+### [OK] ALIGNED: Multi-layer fix options
+
+The user said fixes can be **"at ANY layer -- guardrails, claudechic, workflow, or hybrid."** STATUS.md correctly lists 5 fix directions including hybrid approaches.
+
+### [WARNING] Potential drift risk: Scope of "injection"
+
+The user's framing distinguishes two separate problems:
+1. **Spawn-time injection** -- "The coordinator sends something, but not the actual phase files"
+2. **Phase-transition injection** -- "no automated way to inject updated context to sub-agents during phase transitions"
+
+These require different fixes. The team must not conflate them into one solution. Spawn-time injection is partially working (code exists, depends on coordinator behavior). Phase-transition injection is completely missing.
+
+### [WARNING] Potential drift risk: close_agent scope
+
+The user said **"prevent coordinator from closing agents when it shouldn't."** This is a separate concern from phase injection but explicitly in the user's request. The team must not defer this as "out of scope" -- it was part of the original ask.
+
+### ? NEEDS CLARIFICATION: What "shouldn't" means for close_agent
+
+The user said the coordinator "shouldn't" close agents at certain times but didn't specify the rules. Options:
+- Never close during active phases?
+- Only close after agent reports completion?
+- Require confirmation?
+- Role-based (never close leadership agents)?
+
+**Recommend:** Team should propose specific close_agent guard options rather than asking the user to define the policy.
+
+## Recommendations for the Team
+
+1. **Separate spawn-time vs. transition-time issues** -- they have different root causes and fixes
+2. **Test the spawn-time path** -- Does the coordinator actually pass `type=` when spawning? If not, the existing injection code never triggers. This is testable right now.
+3. **close_agent guards are a MUST** -- Don't let this get deprioritized. It's in the user's explicit request.
+4. **Content gap matters** -- Even perfect injection is useless if roles have no phase files. Consider whether the fix includes adding phase markdown for key roles, or just the mechanism.
+5. **Propose multiple options** -- User explicitly wants options, not one prescribed solution.

--- a/.project_team/subagent_phase_injection/userprompt.md
+++ b/.project_team/subagent_phase_injection/userprompt.md
@@ -1,0 +1,14 @@
+# User Prompt
+
+Investigate GitHub issue #37: Sub-agent phase markdown not injected -- coordinator
+bypasses role phase files.
+
+Sub-agents spawned during workflow phases don't receive their role-specific phase
+instructions (identity.md + {phase}.md). The coordinator sends something, but not
+the actual phase files. Additionally, there is no automated way to inject updated
+context to sub-agents during phase transitions.
+
+Also: prevent coordinator from closing agents when it shouldn't.
+
+The team should investigate what's actually happening and propose fixes at whichever
+layer makes sense (guardrails, claudechic, workflow, or hybrid).

--- a/.project_team/test_audit_and_discipline/SPECIFICATION.md
+++ b/.project_team/test_audit_and_discipline/SPECIFICATION.md
@@ -1,0 +1,141 @@
+# Specification: test_audit_and_discipline
+
+## User Decisions (Locked)
+
+| # | Decision |
+|---|---|
+| 1 | Block **full-suite runs only** — targeted single-test/file runs pass through |
+| 2 | **UTC** timestamps |
+| 3 | **Dual output** — `.xml` (JUnit) + `.log` (tee) for every run |
+| 4 | **Fix fixtures for xdist** — don't mark `serial`, rebuild to be parallel-safe |
+| 5 | **Submodule tests in scope** (`submodules/claudechic/tests/`) |
+| 6 | **`.test_results/`** directory, gitignored |
+| 7 | **Measure baseline timing first** before xdist work |
+
+---
+
+## Axis 1: Claude Code Hook — Block Bare `pytest`
+
+**Goal:** Prevent full-suite pytest runs that don't save results.
+
+**Mechanism:** A `deny` rule in `global/rules.yaml` (claudechic rule system), using the existing pattern alongside `no_rm_rf`, `warn_sudo`, and `log_git_operations`.
+
+**Rule definition:**
+- `id: no_bare_pytest`
+- `trigger: PreToolUse/Bash`
+- `enforcement: deny`
+- `detect.pattern`: regex matching pytest invocations without output saving
+- BLOCK if: command runs pytest with no specific test file target AND no output capture (`tee`, `>`, `--junitxml` pointing to `.test_results/`)
+- ALLOW if: command targets a specific file/function (`pytest tests/test_foo.py::test_bar`)
+- ALLOW if: command includes output to `.test_results/` (via `tee`, redirect, or `--junitxml`)
+- Must catch variants: `pytest`, `pixi run pytest`, `python -m pytest`
+
+**Required output format for full-suite runs:**
+```bash
+pytest --junitxml=.test_results/YYYY-MM-DD_HHMMSS.xml --tb=short 2>&1 | tee .test_results/YYYY-MM-DD_HHMMSS.log
+```
+
+**Timestamps:** UTC, format `YYYY-MM-DD_HHMMSS`, filesystem-safe (no colons).
+
+**Infrastructure:**
+- Create `.test_results/` directory
+- Add `.test_results/` to `.gitignore`
+- New rule in `global/rules.yaml`
+
+**Escape hatch:** Agent can request override (standard claudechic deny behavior). CI has its own artifact saving.
+
+---
+
+## Axis 2: Slow Test Triage & xdist Compatibility
+
+**Step 1: Measure baseline**
+- Run `pytest --durations=0` on the full suite (including slow) and save results
+- Cross-reference actual durations with existing markers
+- Any test >30s without `@pytest.mark.slow` → add marker + explicit timeout override
+
+**Step 2: Fix xdist-incompatible fixtures**
+- `e2e_project` (module-scoped in `tests/conftest.py`) — rebuild using `FileLock` + `tmp_path_factory.getbasetemp().parent` pattern so multiple workers can share safely
+- `generated_project` in `test_e2e_smoke.py` — same treatment
+- `test_mcp_integration.py` `set_app()` global state — isolate per-test
+- `test_cluster_path_mapping.py` / `test_cluster_tools.py` `sys.modules` mutation — verify safe under xdist (separate processes), document
+
+**Step 3: Enable xdist**
+- Add `-n auto` to default `addopts` (or provide a wrapper command)
+- Use `--dist loadscope` to keep module-scoped fixture tests on same worker
+- Verify all tests pass with `pytest -n auto`
+
+**Slow test threshold:** >30s (already codified in pyproject.toml)
+**Timeout gap:** Verify all `@pytest.mark.slow` tests have explicit `@pytest.mark.timeout(N)` overrides above the default 30s.
+
+---
+
+## Axis 3: Critical Test Quality Audit
+
+**Scope:** ALL test files in:
+- `tests/` (13 files)
+- `submodules/claudechic/tests/` (filtered to `test_workflow_*`, `test_hints_*`)
+- `scripts/tests/` (2 files)
+
+**Classification (3 buckets per Skeptic):**
+1. **Intent-based** — tests behavior/contracts, survives refactoring → leave alone
+2. **Necessarily implementation-coupled** — parser tests, regression tests for specific bugs, format validators → label, don't fix
+3. **Gratuitously implementation-coupled** — will break on any refactor for no safety benefit → **rewrite these**
+
+**Heuristics for bucket 3 (from Researcher):**
+- Would the test break if you refactored internals without changing external behavior?
+- Does it test a private/internal method directly?
+- Does it mock 3+ collaborators to isolate a single class?
+- Does the test file mirror the source file 1:1?
+- Does it assert on internal state rather than observable output?
+
+**Known suspects (from Composability + Skeptic):**
+- `test_mcp_discovery.py` regex-extraction-and-exec pattern — "ticking time bomb"
+- Submodule tests with heavy `mock_sdk()` patching — risk of "testing the mock"
+- Any test asserting on exact log messages or mock call counts
+
+**Deliverable:** Short, concrete hit list of tests to rewrite, with before/after sketches. NOT a wall of text. Must identify at least 3-5 concrete rewrites (per Skeptic's constraint).
+
+---
+
+## Axis 4: CI & Test Infrastructure Alignment
+
+**Depends on:** Axes 1 + 2 completion.
+
+**Tasks:**
+- **Refactor `scripts/tests/` into `tests/`:**
+  - Move `test_parser.py` → `tests/test_mine_patterns_parser.py`
+  - **Delete** `test_regression.py` — it's a pure snapshot regression file redundant with `test_parser.py` which already covers the same fixtures with better property-based assertions.
+  - Move `scripts/tests/fixtures/` → `tests/fixtures/mine_patterns/`
+  - Replace `sys.path.insert` hack with proper import (add `scripts` to `pythonpath` in `pyproject.toml`)
+  - Remove `scripts/tests/` after migration
+- Enable xdist in CI (`-n auto`) for fast test job
+- Ensure CI saves JUnit XML artifacts for all test jobs (not just E2E)
+- Document the conftest.py submodule test prefix filter (`test_workflow_*`, `test_hints_*`)
+
+---
+
+## Agent Assignments
+
+| Axis | Agent Type | Priority | Dependencies |
+|------|-----------|----------|-------------|
+| 1. Hook Implementation | Implementer | P0 | None |
+| 2. Slow/xdist Triage | TestEngineer | P0 | None (measure first) |
+| 3. Test Quality Audit | Researcher → TestEngineer | P0 | None (start immediately) |
+| 4. CI Alignment | Implementer | P1 | Axes 1 + 2 |
+
+Axes 1, 2, and 3 launch in parallel. Axis 4 waits.
+
+---
+
+## Terminology (Canonical)
+
+| Term | Definition |
+|---|---|
+| **Intent test** | Tests behavior/contract; survives refactoring |
+| **Implementation test** | Tests internal structure; breaks on refactor |
+| **Bare pytest** | Full-suite run with no output saving |
+| **Timestamped results** | UTC, `YYYY-MM-DD_HHMMSS`, dual `.xml` + `.log` |
+| **xdist-compatible** | Passes correctly under `pytest -n auto` |
+| **Slow test** | >30s, marked `@pytest.mark.slow` with explicit timeout override |
+| **`.test_results/`** | Gitignored directory for all local test output |
+| **Full suite run** | pytest against all `testpaths`, no specific file target |

--- a/.project_team/test_audit_and_discipline/STATUS.md
+++ b/.project_team/test_audit_and_discipline/STATUS.md
@@ -1,0 +1,28 @@
+# Project: test_audit_and_discipline
+# Status: IMPLEMENTATION
+
+## Phase History
+- [2026-04-10] Vision: APPROVED
+- [2026-04-10] Setup: COMPLETE
+- [2026-04-10] Leadership: COMPLETE (5 agents reported)
+- [2026-04-10] Specification: APPROVED
+- [2026-04-10] Implementation: IN PROGRESS
+
+## Agents
+- Composability: ✅ Reported — 4 axes identified, architectural concerns flagged
+- Terminology: ✅ Reported — glossary defined, 5 ambiguities resolved by user
+- Skeptic: ✅ Reported — 3 risks identified, mitigations proposed
+- UserAlignment: ✅ Reported — vision validated, 3 gaps surfaced
+- Researcher: ✅ Reported — best practices for xdist, intent testing, hook patterns
+
+## User Decisions
+1. Block full-suite runs only (not targeted runs)
+2. UTC timestamps
+3. Dual output (.xml + .log)
+4. Fix fixtures for xdist (don't just mark serial)
+5. Submodule tests in scope
+6. `.test_results/` directory, gitignored
+7. Measure baseline timing first
+
+## Blockers
+(none)

--- a/.project_team/test_audit_and_discipline/userprompt.md
+++ b/.project_team/test_audit_and_discipline/userprompt.md
@@ -1,0 +1,20 @@
+# User Prompt
+
+## Raw Request
+Fix slow/flaky tests, enforce disciplined test runs with saved results, and critically audit test quality.
+
+## Vision Summary (Approved)
+
+| Field | Detail |
+|---|---|
+| **Goal** | Fix slow/flaky tests, enforce disciplined test runs with saved results, and critically audit test quality. |
+| **Value** | A 2-min test run fails, output is truncated to ~10 lines, the agent retries blind — pure waste. Tests that mirror implementation instead of intent give false confidence and break on every refactor. Both problems compound. |
+| **Domain Terms** | **xdist** — pytest parallel runner; **intent test** — tests the *why* (behavior/contract); **implementation test** — tests the *how* (fragile, coupled to internals); **test results artifact** — timestamped saved output from a full suite run. |
+| **Success** | 1. A Claude Code hook that blocks bare `pytest` without a file output — forces all full runs to save timestamped results to `test-results/`. 2. Slow and xdist-incompatible tests identified and tagged/fixed. 3. An honest, critical audit of every test: intent-based vs. implementation-based, with concrete recommendations. |
+| **Failure** | We "fix" a few tests superficially, don't enforce the save-results rule, and the audit is a rubber stamp that says "tests look fine" without honest critique. |
+
+## Constraints
+- pytest + pytest-xdist
+- Test results must be timestamped (e.g., `test-results/2026-04-10_143022.log`), not "latest"
+- Bare `pytest` streaming to terminal without saving to a named file must be BLOCKED via hook
+- Audit scope: ALL test files

--- a/template/workflows/project_team/project_team.yaml
+++ b/template/workflows/project_team/project_team.yaml
@@ -70,3 +70,20 @@ rules:
     detect:
       pattern: "git push\\s.*(--force-with-lease|--force\\b|-f\\b)"
     message: "Force push is never allowed"
+
+  - id: prefer_ask_agent
+    trigger: PreToolUse/mcp__chic__tell_agent
+    enforcement: warn
+    message: >-
+      Coordinator should use ask_agent (not tell_agent) to ensure sub-agents
+      respond. tell_agent is fire-and-forget with no reply. Use ask_agent
+      unless you explicitly don't need a response.
+    roles: [coordinator]
+
+  - id: no_close_leadership
+    trigger: PreToolUse/mcp__chic__close_agent
+    enforcement: warn
+    message: >-
+      Do not close agents during active workflow phases. Agents carry context
+      that is lost on close. Wait until signoff phase.
+    exclude_phases: [signoff]

--- a/workflows/project_team/project_team.yaml
+++ b/workflows/project_team/project_team.yaml
@@ -70,3 +70,20 @@ rules:
     detect:
       pattern: "git push\\s.*(--force-with-lease|--force\\b|-f\\b)"
     message: "Force push is never allowed"
+
+  - id: prefer_ask_agent
+    trigger: PreToolUse/mcp__chic__tell_agent
+    enforcement: warn
+    message: >-
+      Coordinator should use ask_agent (not tell_agent) to ensure sub-agents
+      respond. tell_agent is fire-and-forget with no reply. Use ask_agent
+      unless you explicitly don't need a response.
+    roles: [coordinator]
+
+  - id: no_close_leadership
+    trigger: PreToolUse/mcp__chic__close_agent
+    enforcement: warn
+    message: >-
+      Do not close agents during active workflow phases. Agents carry context
+      that is lost on close. Wait until signoff phase.
+    exclude_phases: [signoff]

--- a/workflows/project_team/skeptic/specification.md
+++ b/workflows/project_team/skeptic/specification.md
@@ -4,5 +4,7 @@
 2. Identify risks and failure modes
 3. Distinguish essential complexity (inherent to the problem) from accidental (poor design)
 4. Flag shortcuts disguised as simplicity
-5. Write findings to specification/skeptic_review.md
-6. Report to Coordinator
+5. Flag designs that introduce layers, abstractions, or multi-phase engines when a simpler approach solves the same problem. If a proposal has more than 2 moving parts, ask: can this be done with 1?
+6. Check for complexity carried over from previous spec revisions. When a spec is re-presented after user feedback, verify that old complexity was actually removed -- not just shuffled. Users simplify for a reason; do not let earlier over-engineering sneak back in
+7. Write findings to specification/skeptic_review.md
+8. Report to Coordinator


### PR DESCRIPTION
## Summary
- **Sub-agent phase injection**: Typed sub-agents now receive phase markdown on `advance_phase` broadcast. Coordinator is skipped (inline only). Untyped agents get nothing.
- **Guardrail rules**: Added `prefer_ask_agent` (warn coordinator on `tell_agent`) and `no_close_leadership` (block agent close before signoff) to project-team workflow.
- **Dynamic main agent role**: Main agent resolves `coordinator` role from `main_role` at rule evaluation time (fixes agent_role=None bug).
- **Name fallback removed**: Agent named like a role folder no longer gets that role's content unless `type=` is explicitly set.
- **Spawn warning**: `[WARNING]` when spawning without `type=` during active workflow.
- **Submodule update**: claudechic pinned to `ca003a3` (sprustonlab/claudechic#10)

Also includes prior develop changes:
- claudechic UI upgrade (sidebar files, diff preview, agent switcher)
- Windows path fix for FileItem IDs
- Project team dev history (.project_team/ dirs)

## Test plan
- [x] 16 new tests in `test_phase_injection.py` (no mocking except SDK, real ChatApp + real workflow activation)
- [x] Full claudechic suite (404 passed)
- [x] 5 manual live tests (see `.project_team/subagent_phase_injection/TESTING_PLAN.md`)
- [x] Lint clean
- [ ] CI fast suite (runs automatically on PR)
- [ ] CI full suite (manual dispatch with `run_full` for slow/integration tests)

> **Note**: Submodule PR sprustonlab/claudechic#10 must merge first before this PR's submodule pin resolves on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)